### PR TITLE
chore(solana): provide correct TokenProgram to use

### DIFF
--- a/solana/programs/bridge/src/base_to_solana/instructions/token/finalize_sol_transfer.rs
+++ b/solana/programs/bridge/src/base_to_solana/instructions/token/finalize_sol_transfer.rs
@@ -24,17 +24,15 @@ impl FinalizeBridgeSol {
         let system_program_info = Program::<System>::try_from(next_account_info(&mut iter)?)?;
 
         // Check that the to is correct
-        require!(
-            to_info.key() == self.to,
-            FinalizeBridgeSolError::IncorrectTo
-        );
+        require_keys_eq!(to_info.key(), self.to, FinalizeBridgeSolError::IncorrectTo);
 
         // Check that the sol vault is the expected PDA
         let sol_vault_seeds = &[SOL_VAULT_SEED, self.remote_token.as_ref()];
         let (sol_vault_pda, sol_vault_bump) = Pubkey::find_program_address(sol_vault_seeds, &ID);
 
-        require!(
-            sol_vault_info.key() == sol_vault_pda,
+        require_keys_eq!(
+            sol_vault_info.key(),
+            sol_vault_pda,
             FinalizeBridgeSolError::IncorrectSolVault
         );
 

--- a/solana/programs/bridge/src/base_to_solana/instructions/token/finalize_wrapped_token_transfer.rs
+++ b/solana/programs/bridge/src/base_to_solana/instructions/token/finalize_wrapped_token_transfer.rs
@@ -28,16 +28,18 @@ impl FinalizeBridgeWrappedToken {
             InterfaceAccount::<TokenAccount>::try_from(next_account_info(&mut iter)?)?;
         let token_program_2022 = Program::<Token2022>::try_from(next_account_info(&mut iter)?)?;
 
-        // Check that the to is correct
-        require!(
-            to_token_account.key() == self.to,
-            FinalizeBridgeWrappedTokenError::IncorrectTo
+        // Check that the mint is correct given the local token
+        require_keys_eq!(
+            mint.key(),
+            self.local_token,
+            FinalizeBridgeWrappedTokenError::MintDoesNotMatchLocalToken
         );
 
-        // Check that the mint is correct
-        require!(
-            mint.key() == self.local_token,
-            FinalizeBridgeWrappedTokenError::IncorrectMint
+        // Check that the to is correct given the to address
+        require_keys_eq!(
+            to_token_account.key(),
+            self.to,
+            FinalizeBridgeWrappedTokenError::TokenAccountDoesNotMatchTo,
         );
 
         // Get the partial token metadata
@@ -78,8 +80,8 @@ impl FinalizeBridgeWrappedToken {
 
 #[error_code]
 pub enum FinalizeBridgeWrappedTokenError {
-    #[msg("Incorrect to")]
-    IncorrectTo,
-    #[msg("Incorrect mint")]
-    IncorrectMint,
+    #[msg("Token account does not match to address")]
+    TokenAccountDoesNotMatchTo,
+    #[msg("Mint does not match local token")]
+    MintDoesNotMatchLocalToken,
 }

--- a/solana/scripts/base-to-solana/relay-message.ts
+++ b/solana/scripts/base-to-solana/relay-message.ts
@@ -1,6 +1,10 @@
 import * as anchor from "@coral-xyz/anchor";
 import { Program } from "@coral-xyz/anchor";
-import { TOKEN_2022_PROGRAM_ID, TOKEN_PROGRAM_ID } from "@solana/spl-token";
+import {
+  getMint,
+  TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
+} from "@solana/spl-token";
 import { PublicKey, SystemProgram } from "@solana/web3.js";
 import { toBytes, toHex } from "viem";
 
@@ -156,6 +160,14 @@ async function main() {
         program.programId
       );
 
+      const mint = await program.provider.connection.getAccountInfo(
+        splTransfer.localToken
+      );
+
+      if (!mint) {
+        throw new Error("Mint not found");
+      }
+
       remainingAccounts = [
         {
           pubkey: splTransfer.localToken,
@@ -173,12 +185,7 @@ async function main() {
           isSigner: false,
         },
         {
-          pubkey: TOKEN_PROGRAM_ID,
-          isWritable: false,
-          isSigner: false,
-        },
-        {
-          pubkey: TOKEN_2022_PROGRAM_ID,
+          pubkey: mint.owner,
           isWritable: false,
           isSigner: false,
         },


### PR DESCRIPTION
Simplify the `FinalizeBridgeSpl` instruction by accepting a single `Interface::<TokenInterface>`  instead of the two version of the token program.

Also brings some minor cleaning on other "finalize" instructions.