### PR TITLE
fix(CHAIN-1709): add check to MMR proof validation

### DIFF
--- a/solana/programs/bridge/src/base_to_solana/internal/mmr.rs
+++ b/solana/programs/bridge/src/base_to_solana/internal/mmr.rs
@@ -31,6 +31,7 @@ pub fn verify_proof(expected_root: &[u8; 32], leaf_hash: &[u8; 32], proof: &Proo
     if *total_leaf_count == 0 {
         require!(proof.is_empty(), MmrError::MmrShouldBeEmpty);
         require!(*expected_root == [0u8; 32], MmrError::InvalidProof);
+        require!(*leaf_hash == [0u8; 32], MmrError::InvalidProof);
         return Ok(());
     }
 


### PR DESCRIPTION
Ensures that `leaf_hash` is 0 in the case `total_leaf_count == 0`