### PR TITLE
chore(solana): force separate call buffer creation

### DIFF
--- a/solana/programs/bridge/src/lib.rs
+++ b/solana/programs/bridge/src/lib.rs
@@ -271,16 +271,14 @@ pub mod bridge {
     /// * `to`           - The target contract address on Base
     /// * `value`        - The amount of ETH to send with the call (in wei)
     /// * `initial_data` - Initial call data to store
-    /// * `max_data_len` - Maximum total length of data that will be stored
     pub fn initialize_call_buffer(
         ctx: Context<InitializeCallBuffer>,
         ty: CallType,
         to: [u8; 20],
         value: u128,
         initial_data: Vec<u8>,
-        max_data_len: usize,
     ) -> Result<()> {
-        initialize_call_buffer_handler(ctx, ty, to, value, initial_data, max_data_len)
+        initialize_call_buffer_handler(ctx, ty, to, value, initial_data)
     }
 
     /// Appends data to an existing call buffer account.

--- a/solana/programs/bridge/src/solana_to_base/instructions/buffered/append_to_call_buffer.rs
+++ b/solana/programs/bridge/src/solana_to_base/instructions/buffered/append_to_call_buffer.rs
@@ -51,18 +51,22 @@ mod tests {
     use crate::{
         accounts,
         instruction::{AppendToCallBuffer as AppendToCallBufferIx, InitializeCallBuffer},
-        solana_to_base::CallType,
-        test_utils::setup_bridge_and_svm,
+        solana_to_base::{CallBuffer, CallType},
+        test_utils::{create_call_buffer, setup_bridge_and_svm},
         ID,
     };
 
     fn setup_call_buffer(
         svm: &mut litesvm::LiteSVM,
         owner: &solana_keypair::Keypair,
-        call_buffer: &solana_keypair::Keypair,
         initial_data: Vec<u8>,
-    ) {
-        // Initialize the call buffer first
+        remaining_space: Option<usize>,
+    ) -> solana_keypair::Keypair {
+        // Create and initialize the call buffer
+        let required_space =
+            8 + CallBuffer::space(initial_data.len() + remaining_space.unwrap_or_default());
+        let call_buffer = create_call_buffer(svm, owner, required_space);
+
         let init_accounts = accounts::InitializeCallBuffer {
             payer: owner.pubkey(),
             call_buffer: call_buffer.pubkey(),
@@ -78,19 +82,20 @@ mod tests {
                 to: [1u8; 20],
                 value: 0u128,
                 initial_data,
-                max_data_len: 1024,
             }
             .data(),
         };
 
         let init_tx = Transaction::new(
-            &[owner, call_buffer],
+            &[owner],
             Message::new(&[init_ix], Some(&owner.pubkey())),
             svm.latest_blockhash(),
         );
 
         svm.send_transaction(init_tx)
             .expect("Failed to initialize call buffer");
+
+        call_buffer
     }
 
     #[test]
@@ -101,12 +106,9 @@ mod tests {
         let owner = Keypair::new();
         svm.airdrop(&owner.pubkey(), LAMPORTS_PER_SOL).unwrap();
 
-        // Create call buffer account
-        let call_buffer = Keypair::new();
-
         // Setup call buffer with initial data
         let initial_data = vec![0x12, 0x34];
-        setup_call_buffer(&mut svm, &owner, &call_buffer, initial_data.clone());
+        let call_buffer = setup_call_buffer(&mut svm, &owner, initial_data.clone(), Some(3));
 
         // Append additional data
         let append_data = vec![0x56, 0x78, 0x9a];
@@ -162,12 +164,9 @@ mod tests {
         svm.airdrop(&unauthorized.pubkey(), LAMPORTS_PER_SOL)
             .unwrap();
 
-        // Create call buffer account
-        let call_buffer = Keypair::new();
-
         // Setup call buffer with owner
         let initial_data = vec![0x12, 0x34];
-        setup_call_buffer(&mut svm, &owner, &call_buffer, initial_data);
+        let call_buffer = setup_call_buffer(&mut svm, &owner, initial_data, Some(2));
 
         // Try to append data with unauthorized account
         let append_data = vec![0x56, 0x78];

--- a/solana/programs/bridge/src/solana_to_base/instructions/buffered/bridge_sol.rs
+++ b/solana/programs/bridge/src/solana_to_base/instructions/buffered/bridge_sol.rs
@@ -133,8 +133,8 @@ mod tests {
         instruction::{
             BridgeSolWithBufferedCall as BridgeSolWithBufferedCallIx, InitializeCallBuffer,
         },
-        solana_to_base::{CallType, GAS_FEE_RECEIVER, NATIVE_SOL_PUBKEY},
-        test_utils::setup_bridge_and_svm,
+        solana_to_base::{CallBuffer, CallType, GAS_FEE_RECEIVER, NATIVE_SOL_PUBKEY},
+        test_utils::{create_call_buffer, setup_bridge_and_svm},
         ID,
     };
 
@@ -153,9 +153,6 @@ mod tests {
         // Airdrop to gas fee receiver
         svm.airdrop(&GAS_FEE_RECEIVER, LAMPORTS_PER_SOL).unwrap();
 
-        // Create call buffer account
-        let call_buffer = Keypair::new();
-
         // Test parameters
         let gas_limit = 1_000_000u64;
         let to = [1u8; 20];
@@ -167,9 +164,11 @@ mod tests {
         let call_to = [3u8; 20];
         let call_value = 200u128;
         let call_data = vec![0x11, 0x22, 0x33, 0x44];
-        let max_data_len = 1024;
 
-        // First, initialize the call buffer
+        // Create and initialize the call buffer
+        let required_space = 8 + CallBuffer::space(call_data.len());
+        let call_buffer = create_call_buffer(&mut svm, &owner, required_space);
+
         let init_accounts = accounts::InitializeCallBuffer {
             payer: owner.pubkey(),
             call_buffer: call_buffer.pubkey(),
@@ -185,13 +184,12 @@ mod tests {
                 to: call_to,
                 value: call_value,
                 initial_data: call_data.clone(),
-                max_data_len,
             }
             .data(),
         };
 
         let init_tx = Transaction::new(
-            &[&owner, &call_buffer],
+            &[&owner],
             Message::new(&[init_ix], Some(&owner.pubkey())),
             svm.latest_blockhash(),
         );
@@ -331,10 +329,11 @@ mod tests {
         // Airdrop to gas fee receiver
         svm.airdrop(&GAS_FEE_RECEIVER, LAMPORTS_PER_SOL).unwrap();
 
-        // Create call buffer account
-        let call_buffer = Keypair::new();
+        // Create and initialize the call buffer with owner
+        let call_data = vec![0x12, 0x34];
+        let required_space = 8 + CallBuffer::space(call_data.len());
+        let call_buffer = create_call_buffer(&mut svm, &owner, required_space);
 
-        // First, initialize the call buffer with owner
         let init_accounts = accounts::InitializeCallBuffer {
             payer: owner.pubkey(),
             call_buffer: call_buffer.pubkey(),
@@ -349,14 +348,13 @@ mod tests {
                 ty: CallType::Call,
                 to: [1u8; 20],
                 value: 0,
-                initial_data: vec![0x12, 0x34],
-                max_data_len: 1024,
+                initial_data: call_data,
             }
             .data(),
         };
 
         let init_tx = Transaction::new(
-            &[&owner, &call_buffer],
+            &[&owner],
             Message::new(&[init_ix], Some(&owner.pubkey())),
             svm.latest_blockhash(),
         );
@@ -442,10 +440,11 @@ mod tests {
         svm.airdrop(&wrong_gas_fee_receiver.pubkey(), LAMPORTS_PER_SOL)
             .unwrap();
 
-        // Create call buffer account
-        let call_buffer = Keypair::new();
+        // Create and initialize the call buffer
+        let call_data = vec![0x12, 0x34];
+        let required_space = 8 + CallBuffer::space(call_data.len());
+        let call_buffer = create_call_buffer(&mut svm, &owner, required_space);
 
-        // Initialize the call buffer
         let init_accounts = accounts::InitializeCallBuffer {
             payer: owner.pubkey(),
             call_buffer: call_buffer.pubkey(),
@@ -460,14 +459,13 @@ mod tests {
                 ty: CallType::Call,
                 to: [1u8; 20],
                 value: 0,
-                initial_data: vec![0x12, 0x34],
-                max_data_len: 1024,
+                initial_data: call_data,
             }
             .data(),
         };
 
         let init_tx = Transaction::new(
-            &[&owner, &call_buffer],
+            &[&owner],
             Message::new(&[init_ix], Some(&owner.pubkey())),
             svm.latest_blockhash(),
         );

--- a/solana/programs/bridge/src/solana_to_base/instructions/buffered/bridge_spl.rs
+++ b/solana/programs/bridge/src/solana_to_base/instructions/buffered/bridge_spl.rs
@@ -160,8 +160,10 @@ mod tests {
         instruction::{
             BridgeSplWithBufferedCall as BridgeSplWithBufferedCallIx, InitializeCallBuffer,
         },
-        solana_to_base::{CallType, GAS_FEE_RECEIVER},
-        test_utils::{create_mock_mint, create_mock_token_account, setup_bridge_and_svm},
+        solana_to_base::{CallBuffer, CallType, GAS_FEE_RECEIVER},
+        test_utils::{
+            create_call_buffer, create_mock_mint, create_mock_token_account, setup_bridge_and_svm,
+        },
         ID,
     };
 
@@ -200,9 +202,6 @@ mod tests {
             initial_amount,
         );
 
-        // Create call buffer account
-        let call_buffer = Keypair::new();
-
         // Test parameters
         let gas_limit = 1_000_000u64;
         let to = [1u8; 20];
@@ -214,9 +213,11 @@ mod tests {
         let call_to = [3u8; 20];
         let call_value = 200u128;
         let call_data = vec![0x11, 0x22, 0x33, 0x44];
-        let max_data_len = 1024;
 
-        // First, initialize the call buffer
+        // Create and initialize the call buffer
+        let required_space = 8 + CallBuffer::space(call_data.len());
+        let call_buffer = create_call_buffer(&mut svm, &owner, required_space);
+
         let init_accounts = accounts::InitializeCallBuffer {
             payer: owner.pubkey(),
             call_buffer: call_buffer.pubkey(),
@@ -232,13 +233,12 @@ mod tests {
                 to: call_to,
                 value: call_value,
                 initial_data: call_data.clone(),
-                max_data_len,
             }
             .data(),
         };
 
         let init_tx = Transaction::new(
-            &[&owner, &call_buffer],
+            &[&owner],
             Message::new(&[init_ix], Some(&owner.pubkey())),
             svm.latest_blockhash(),
         );
@@ -403,10 +403,11 @@ mod tests {
             initial_amount,
         );
 
-        // Create call buffer account
-        let call_buffer = Keypair::new();
+        // Create and initialize the call buffer with owner
+        let call_data = vec![0x12, 0x34];
+        let required_space = 8 + CallBuffer::space(call_data.len());
+        let call_buffer = create_call_buffer(&mut svm, &owner, required_space);
 
-        // First, initialize the call buffer with owner
         let init_accounts = accounts::InitializeCallBuffer {
             payer: owner.pubkey(),
             call_buffer: call_buffer.pubkey(),
@@ -421,14 +422,13 @@ mod tests {
                 ty: CallType::Call,
                 to: [1u8; 20],
                 value: 0,
-                initial_data: vec![0x12, 0x34],
-                max_data_len: 1024,
+                initial_data: call_data,
             }
             .data(),
         };
 
         let init_tx = Transaction::new(
-            &[&owner, &call_buffer],
+            &[&owner],
             Message::new(&[init_ix], Some(&owner.pubkey())),
             svm.latest_blockhash(),
         );
@@ -540,10 +540,11 @@ mod tests {
             initial_amount,
         );
 
-        // Create call buffer account
-        let call_buffer = Keypair::new();
+        // Create and initialize the call buffer
+        let call_data = vec![0x12, 0x34];
+        let required_space = 8 + CallBuffer::space(call_data.len());
+        let call_buffer = create_call_buffer(&mut svm, &owner, required_space);
 
-        // Initialize the call buffer
         let init_accounts = accounts::InitializeCallBuffer {
             payer: owner.pubkey(),
             call_buffer: call_buffer.pubkey(),
@@ -558,14 +559,13 @@ mod tests {
                 ty: CallType::Call,
                 to: [1u8; 20],
                 value: 0,
-                initial_data: vec![0x12, 0x34],
-                max_data_len: 1024,
+                initial_data: call_data,
             }
             .data(),
         };
 
         let init_tx = Transaction::new(
-            &[&owner, &call_buffer],
+            &[&owner],
             Message::new(&[init_ix], Some(&owner.pubkey())),
             svm.latest_blockhash(),
         );

--- a/solana/programs/bridge/src/solana_to_base/instructions/buffered/initialize_call_buffer.rs
+++ b/solana/programs/bridge/src/solana_to_base/instructions/buffered/initialize_call_buffer.rs
@@ -3,24 +3,24 @@ use anchor_lang::prelude::*;
 use crate::solana_to_base::{CallBuffer, CallType, MAX_CALL_BUFFER_SIZE};
 
 /// Accounts struct for initializing a call buffer account that can store large call data.
-/// This account can be used to build up call data over multiple transactions before bridging.
+/// The account must be pre-allocated by the user to avoid CPI size limitations.
 #[derive(Accounts)]
-#[instruction(_ty: CallType, _to: [u8; 20], _value: u128, _initial_data: Vec<u8>, max_data_len: usize)]
+#[instruction(_ty: CallType, _to: [u8; 20], _value: u128, initial_data: Vec<u8>)]
 pub struct InitializeCallBuffer<'info> {
-    /// The account paying for the transaction fees and the call buffer account creation.
-    /// It is set as the owner of the call buffer account.
+    /// The account paying for the transaction fees.
     #[account(mut)]
     pub payer: Signer<'info>,
 
-    /// The call buffer account being created.
+    /// CHECK: We will initialize this account
+    /// The call buffer account to initialize (must be pre-allocated by the user).
     #[account(
-        init,
-        payer = payer,
-        space = CallBuffer::space(max_data_len),
+        mut,
+        owner = crate::ID,
+        constraint = call_buffer.data_len() <= 8 + CallBuffer::space(MAX_CALL_BUFFER_SIZE) @ InitializeCallBufferError::MaxSizeExceeded,
     )]
-    pub call_buffer: Account<'info, CallBuffer>,
+    pub call_buffer: AccountInfo<'info>,
 
-    /// System program for account creation.
+    /// System program (kept for compatibility but not used since account is pre-allocated).
     pub system_program: Program<'info, System>,
 }
 
@@ -30,15 +30,17 @@ pub fn initialize_call_buffer_handler(
     to: [u8; 20],
     value: u128,
     initial_data: Vec<u8>,
-    max_data_len: usize,
 ) -> Result<()> {
-    // Verify that the max data length doesn't exceed the max allowed size.
-    require!(
-        max_data_len <= MAX_CALL_BUFFER_SIZE,
-        InitializeCallBufferError::MaxSizeExceeded
-    );
+    // Ensure account is not already initialized
+    const DISCRIMINATOR_LEN: usize = CallBuffer::DISCRIMINATOR.len();
+    let call_buffer_data = ctx.accounts.call_buffer.try_borrow_data()?;
+    if call_buffer_data[..DISCRIMINATOR_LEN] != [0u8; DISCRIMINATOR_LEN] {
+        return Err(InitializeCallBufferError::AlreadyInitialized.into());
+    }
+    drop(call_buffer_data);
 
-    *ctx.accounts.call_buffer = CallBuffer {
+    // Create the CallBuffer struct
+    let call_buffer = CallBuffer {
         owner: ctx.accounts.payer.key(),
         ty,
         to,
@@ -46,13 +48,20 @@ pub fn initialize_call_buffer_handler(
         data: initial_data,
     };
 
+    // Serialize the account data.
+    // NOTE: This will write the discriminator to the account.
+    let mut call_buffer_data = ctx.accounts.call_buffer.try_borrow_mut_data()?;
+    CallBuffer::try_serialize(&call_buffer, &mut &mut call_buffer_data[..])?;
+
     Ok(())
 }
 
 #[error_code]
 pub enum InitializeCallBufferError {
-    #[msg("Call buffer size exceeds maximum allowed size of 64KB")]
+    #[msg("Call buffer size exceeds maximum allowed size")]
     MaxSizeExceeded,
+    #[msg("Account is already initialized")]
+    AlreadyInitialized,
 }
 
 #[cfg(test)]
@@ -69,8 +78,11 @@ mod tests {
     use solana_transaction::Transaction;
 
     use crate::{
-        accounts, instruction::InitializeCallBuffer as InitializeCallBufferIx,
-        solana_to_base::CallType, test_utils::setup_bridge_and_svm, ID,
+        accounts,
+        instruction::InitializeCallBuffer as InitializeCallBufferIx,
+        solana_to_base::{CallBuffer, CallType, MAX_CALL_BUFFER_SIZE},
+        test_utils::{create_call_buffer, setup_bridge_and_svm},
+        ID,
     };
 
     #[test]
@@ -81,17 +93,17 @@ mod tests {
         let payer = Keypair::new();
         svm.airdrop(&payer.pubkey(), LAMPORTS_PER_SOL).unwrap();
 
-        // Create call buffer account
-        let call_buffer = Keypair::new();
-
         // Test parameters
         let ty = CallType::Call;
         let to = [1u8; 20];
         let value = 100u128;
         let initial_data = vec![0x12, 0x34, 0x56, 0x78];
-        let max_data_len = 1024;
 
-        // Build the InitializeCallBuffer instruction accounts
+        // Create call buffer account
+        let required_space = 8 + CallBuffer::space(initial_data.len());
+        let call_buffer = create_call_buffer(&mut svm, &payer, required_space);
+
+        // Build the InitializeCallBuffer instruction
         let accounts = accounts::InitializeCallBuffer {
             payer: payer.pubkey(),
             call_buffer: call_buffer.pubkey(),
@@ -99,7 +111,6 @@ mod tests {
         }
         .to_account_metas(None);
 
-        // Build the InitializeCallBuffer instruction
         let ix = Instruction {
             program_id: ID,
             accounts,
@@ -108,14 +119,12 @@ mod tests {
                 to,
                 value,
                 initial_data: initial_data.clone(),
-                max_data_len,
             }
             .data(),
         };
 
-        // Build the transaction
         let tx = Transaction::new(
-            &[&payer, &call_buffer],
+            &[&payer],
             Message::new(&[ix], Some(&payer.pubkey())),
             svm.latest_blockhash(),
         );
@@ -139,68 +148,125 @@ mod tests {
         assert_eq!(call_buffer_data.data, initial_data);
     }
 
-    // TODO: Uncomment once we implemented proper realloc to allow reaching the max size
-    //       https://stackoverflow.com/a/70156099
-    // #[test]
-    // fn test_initialize_call_buffer_max_size_exceeded() {
-    //     let (mut svm, _payer, _bridge_pda) = setup_bridge_and_svm();
+    #[test]
+    fn test_initialize_call_buffer_already_initialized() {
+        let (mut svm, _payer, _bridge_pda) = setup_bridge_and_svm();
 
-    //     // Create payer account
-    //     let payer = Keypair::new();
-    //     svm.airdrop(&payer.pubkey(), LAMPORTS_PER_SOL).unwrap();
+        // Create payer account
+        let payer = Keypair::new();
+        svm.airdrop(&payer.pubkey(), LAMPORTS_PER_SOL).unwrap();
 
-    //     // Create call buffer account
-    //     let call_buffer = Keypair::new();
+        // Test parameters
+        let ty = CallType::Call;
+        let to = [1u8; 20];
+        let value = 100u128;
+        let initial_data = vec![0x12, 0x34, 0x56, 0x78];
 
-    //     // Test parameters with max_data_len exceeding MAX_CALL_BUFFER_SIZE
-    //     let ty = CallType::Call;
-    //     let to = [1u8; 20];
-    //     let value = 0u128;
-    //     let initial_data = vec![0x12, 0x34];
-    //     let max_data_len = MAX_CALL_BUFFER_SIZE + 1; // Exceed the limit
+        // Create call buffer account
+        let required_space = 8 + CallBuffer::space(initial_data.len());
+        let call_buffer = create_call_buffer(&mut svm, &payer, required_space);
 
-    //     // Build the InitializeCallBuffer instruction accounts
-    //     let accounts = accounts::InitializeCallBuffer {
-    //         payer: payer.pubkey(),
-    //         call_buffer: call_buffer.pubkey(),
-    //         system_program: system_program::ID,
-    //     }
-    //     .to_account_metas(None);
+        let accounts = accounts::InitializeCallBuffer {
+            payer: payer.pubkey(),
+            call_buffer: call_buffer.pubkey(),
+            system_program: system_program::ID,
+        }
+        .to_account_metas(None);
 
-    //     // Build the InitializeCallBuffer instruction
-    //     let ix = Instruction {
-    //         program_id: ID,
-    //         accounts,
-    //         data: InitializeCallBufferIx {
-    //             ty,
-    //             to,
-    //             value,
-    //             initial_data,
-    //             max_data_len,
-    //         }
-    //         .data(),
-    //     };
+        let ix = Instruction {
+            program_id: ID,
+            accounts,
+            data: InitializeCallBufferIx {
+                ty,
+                to,
+                value,
+                initial_data: initial_data.clone(),
+            }
+            .data(),
+        };
 
-    //     // Build the transaction
-    //     let tx = Transaction::new(
-    //         &[&payer, &call_buffer],
-    //         Message::new(&[ix], Some(&payer.pubkey())),
-    //         svm.latest_blockhash(),
-    //     );
+        // Build the transaction with two initialization instructions
+        let tx = Transaction::new(
+            &[&payer],
+            Message::new(&[ix.clone(), ix], Some(&payer.pubkey())),
+            svm.latest_blockhash(),
+        );
 
-    //     // Send the transaction - should fail
-    //     let result = svm.send_transaction(tx);
-    //     assert!(
-    //         result.is_err(),
-    //         "Expected transaction to fail with max size exceeded"
-    //     );
+        // Send the transaction - should fail with AlreadyInitialized
+        let result = svm.send_transaction(tx);
+        assert!(
+            result.is_err(),
+            "Expected transaction to fail with already initialized error"
+        );
 
-    //     // Check that the error contains the expected error message
-    //     let error_string = format!("{:?}", result.unwrap_err());
-    //     assert!(
-    //         error_string.contains("MaxSizeExceeded"),
-    //         "Expected MaxSizeExceeded error, got: {}",
-    //         error_string
-    //     );
-    // }
+        // Check that the error contains the expected error message
+        let error_string = format!("{:?}", result.unwrap_err());
+        assert!(
+            error_string.contains("AlreadyInitialized"),
+            "Expected AlreadyInitialized error, got: {}",
+            error_string
+        );
+    }
+
+    #[test]
+    fn test_initialize_call_buffer_max_size_exceeded() {
+        let (mut svm, _payer, _bridge_pda) = setup_bridge_and_svm();
+
+        // Create payer account
+        let payer = Keypair::new();
+        svm.airdrop(&payer.pubkey(), LAMPORTS_PER_SOL * 10).unwrap(); // Extra SOL for large account
+
+        // Test parameters
+        let ty = CallType::Call;
+        let to = [1u8; 20];
+        let value = 0u128;
+        let initial_data = vec![0x12, 0x34];
+
+        // Calculate a size that exceeds the maximum allowed size
+        let excessive_size = 8 + CallBuffer::space(MAX_CALL_BUFFER_SIZE) + 1;
+
+        // Create call buffer account with excessive size
+        let call_buffer = create_call_buffer(&mut svm, &payer, excessive_size);
+
+        // Build the InitializeCallBuffer instruction
+        let accounts = accounts::InitializeCallBuffer {
+            payer: payer.pubkey(),
+            call_buffer: call_buffer.pubkey(),
+            system_program: system_program::ID,
+        }
+        .to_account_metas(None);
+
+        let ix = Instruction {
+            program_id: ID,
+            accounts,
+            data: InitializeCallBufferIx {
+                ty,
+                to,
+                value,
+                initial_data,
+            }
+            .data(),
+        };
+
+        let tx = Transaction::new(
+            &[&payer],
+            Message::new(&[ix], Some(&payer.pubkey())),
+            svm.latest_blockhash(),
+        );
+
+        // Send the transaction - should fail with MaxSizeExceeded
+        let result = svm.send_transaction(tx);
+        assert!(
+            result.is_err(),
+            "Expected transaction to fail with max size exceeded"
+        );
+
+        // Check that the error contains the expected error message
+        let error_string = format!("{:?}", result.unwrap_err());
+        assert!(
+            error_string.contains("MaxSizeExceeded"),
+            "Expected MaxSizeExceeded error, got: {}",
+            error_string
+        );
+    }
 }

--- a/solana/programs/bridge/src/test_utils/mod.rs
+++ b/solana/programs/bridge/src/test_utils/mod.rs
@@ -1,4 +1,10 @@
-use anchor_lang::{prelude::*, solana_program::native_token::LAMPORTS_PER_SOL};
+use anchor_lang::{
+    prelude::*,
+    solana_program::{
+        instruction::Instruction, native_token::LAMPORTS_PER_SOL, system_instruction,
+    },
+    system_program, InstructionData,
+};
 use anchor_spl::{
     token_2022::spl_token_2022::{
         extension::{
@@ -17,21 +23,18 @@ use anchor_spl::{
 };
 use litesvm::LiteSVM;
 use solana_account::Account;
+use solana_keypair::Keypair;
+use solana_message::Message;
+use solana_signer::Signer;
+use solana_transaction::Transaction;
 
-use crate::common::{PartialTokenMetadata, WRAPPED_TOKEN_SEED};
+use crate::{
+    accounts,
+    common::{PartialTokenMetadata, BRIDGE_SEED, WRAPPED_TOKEN_SEED},
+    ID,
+};
 
 pub fn setup_bridge_and_svm() -> (LiteSVM, solana_keypair::Keypair, Pubkey) {
-    use anchor_lang::{
-        solana_program::{instruction::Instruction, native_token::LAMPORTS_PER_SOL},
-        system_program, InstructionData,
-    };
-    use solana_keypair::Keypair;
-    use solana_message::Message;
-    use solana_signer::Signer;
-    use solana_transaction::Transaction;
-
-    use crate::{accounts, common::BRIDGE_SEED, ID};
-
     let mut svm = LiteSVM::new();
     svm.add_program_from_file(ID, "../../target/deploy/bridge.so")
         .unwrap();
@@ -202,4 +205,31 @@ pub fn create_mock_wrapped_mint(
     .unwrap();
 
     wrapped_mint
+}
+
+pub fn create_call_buffer(svm: &mut LiteSVM, owner: &Keypair, size: usize) -> Keypair {
+    let call_buffer = Keypair::new();
+
+    // Pre-allocate the account using System Program
+    let rent = svm.minimum_balance_for_rent_exemption(size);
+    let ix = system_instruction::create_account(
+        &owner.pubkey(),
+        &call_buffer.pubkey(),
+        rent,
+        size as u64,
+        &crate::ID,
+    );
+
+    // Build the transaction
+    let tx = Transaction::new(
+        &[owner, &call_buffer],
+        Message::new(&[ix], Some(&owner.pubkey())),
+        svm.latest_blockhash(),
+    );
+
+    // Send the transaction
+    svm.send_transaction(tx)
+        .expect("Failed to create call buffer account");
+
+    call_buffer
 }


### PR DESCRIPTION
This PR follows https://github.com/base/bridge/pull/34 and fixes the [10KB account size restriction](https://stackoverflow.com/a/70156099) we were facing due to realloc operations performed via CPI.

## Problem

Solana has a 10KB limit for account creation/reallocation via CPI, which was preventing us from creating larger call buffer accounts needed for complex bridge operations.

## Solution

We've implemented a "Bring Your Own Account" (BYOA) pattern where:
- Users must pre-allocate call buffer accounts using direct System Program calls (not via CPI)
- The `initialize_call_buffer` instruction now accepts pre-allocated accounts and initializes them
- This bypasses the 10KB CPI limitation since the account creation happens outside of our program