### PR TITLE
Reduce call buffer limit to 8kb

### DIFF
--- a/base/.gitignore
+++ b/base/.gitignore
@@ -15,3 +15,4 @@ docs/
 
 lib/
 deployments/anvil.json
+deployments/Anvil.json

--- a/base/src/Bridge.sol
+++ b/base/src/Bridge.sol
@@ -72,10 +72,10 @@ contract Bridge is ReentrancyGuardTransient, Initializable, OwnableRoles {
     /// @dev Simulated via a forge test performing a call to `relayMessages` with a single message where:
     ///      - The execution and the execution epilogue sections were commented out to isolate the execution section.
     ///      - `isTrustedRelayer` was true to estimate the worst case scenario of doing an additional SSTORE.
-    ///      - The `message.data` field was 64Kb large which is the maximum size allowed for the data field of an
+    ///      - The `message.data` field was 8Kb large which is the maximum size allowed for the data field of an
     ///        `OutgoingMessage` on the Solana side.
-    ///      - The metered gas was 61,543 gas.
-    uint256 private constant _EXECUTION_PROLOGUE_GAS_BUFFER = 65_000;
+    ///      - The metered gas was 14,798 gas.
+    uint256 private constant _EXECUTION_PROLOGUE_GAS_BUFFER = 20_000;
 
     /// @notice Gas required to run the execution section of `__validateAndRelay`.
     ///
@@ -83,23 +83,23 @@ contract Bridge is ReentrancyGuardTransient, Initializable, OwnableRoles {
     ///      - The execution epilogue section was commented out to isolate the execution section. The execution section
     ///        (body of the `__relayMessage` function) was commented out to isolate the cost of performing the public
     ///        call to `this.__relayMessage` specifically.
-    ///      - The `message.data` field was 64Kb large which is the maximum size allowed for the data field of an
+    ///      - The `message.data` field was 8Kb large which is the maximum size allowed for the data field of an
     ///        `OutgoingMessage` on the Solana side.
-    ///      - The metered gas (including the execution prologue section) was 100,674 gas thus the isolated
-    ///        execution section was 100,674 - 61,543 = 39,131 gas.
+    ///      - The metered gas (including the execution prologue section) was 18,495 gas thus the isolated
+    ///        execution section was 18,495 - 14,798 = 3,697 gas.
     ///      - No buffer is strictly needed as the `_EXECUTION_PROLOGUE_GAS_BUFFER` is already rounded up and above
     ///        that.
-    uint256 private constant _EXECUTION_GAS_BUFFER = 40_000;
+    uint256 private constant _EXECUTION_GAS_BUFFER = 5_000;
 
     /// @notice Gas required to run the execution epilogue section of `__validateAndRelay`.
     ///
     /// @dev Simulated via a forge test performing a single call to `__validateAndRelay` where:
     ///      - The execution section (body of the `__relayMessage` function) was commented out to isolate the cost of
     ///        performing the public call to `this.__relayMessage` and the success / failure bookkeeping specifically.
-    ///      - The `message.data` field was 64Kb large which is the maximum size allowed for the data field of an
+    ///      - The `message.data` field was 8kb large which is the maximum size allowed for the data field of an
     ///        `OutgoingMessage` on the Solana side.
-    ///      - The metered gas (including the execution prologue and execution sections) was 121,996 gas thus the
-    ///        isolated execution epilogue section was 121,996 - 100,674 = 21,322 gas.
+    ///      - The metered gas (including the execution prologue and execution sections) was 40,118 gas thus the
+    ///        isolated execution epilogue section was 40,118 - 18,495 = 21,623 gas.
     uint256 private constant _EXECUTION_EPILOGUE_GAS_BUFFER = 25_000;
 
     //////////////////////////////////////////////////////////////
@@ -119,7 +119,7 @@ contract Bridge is ReentrancyGuardTransient, Initializable, OwnableRoles {
     mapping(Pubkey owner => address twinAddress) public twins;
 
     /// @notice The nonce used for the next incoming message relayed.
-    uint64 public nextIncomingNonce = 1;
+    uint64 public nextIncomingNonce;
 
     /// @notice Whether the bridge is paused.
     bool public paused;
@@ -196,6 +196,8 @@ contract Bridge is ReentrancyGuardTransient, Initializable, OwnableRoles {
         TRUSTED_RELAYER = trustedRelayer;
         TWIN_BEACON = twinBeacon;
         CROSS_CHAIN_ERC20_FACTORY = crossChainErc20Factory;
+
+        nextIncomingNonce = 1;
 
         _disableInitializers();
     }

--- a/base/test/CrossChainERC20Factory.t.sol
+++ b/base/test/CrossChainERC20Factory.t.sol
@@ -214,14 +214,11 @@ contract CrossChainERC20FactoryTest is Test {
         bytes32 remoteToken,
         string memory name,
         string memory symbol,
-        uint8 decimals,
-        address randomDeployer1,
-        address randomDeployer2
+        uint8 decimals
     ) public {
-        // Ensure deployers are different and valid
-        vm.assume(randomDeployer1 != randomDeployer2);
-        vm.assume(randomDeployer1 != address(0));
-        vm.assume(randomDeployer2 != address(0));
+        // Generate 2 random deployer addresses.
+        address randomDeployer1 = makeAddr(string.concat("deployer1", vm.toString(remoteToken)));
+        address randomDeployer2 = makeAddr(string.concat("deployer2", vm.toString(remoteToken)));
 
         // Calculate expected address
         bytes32 salt = keccak256(abi.encode(remoteToken, name, symbol, decimals));
@@ -309,21 +306,5 @@ contract CrossChainERC20FactoryTest is Test {
         vm.prank(deployer);
         address token = factory.deploy(REMOTE_TOKEN, TOKEN_NAME, TOKEN_SYMBOL, TOKEN_DECIMALS);
         assertTrue(token != address(0), "Factory should continue working after implementation changes");
-    }
-
-    //////////////////////////////////////////////////////////////
-    ///                   Helper Functions                    ///
-    //////////////////////////////////////////////////////////////
-
-    /// @dev Helper function to generate unique test parameters
-    function generateUniqueParams(uint256 seed)
-        internal
-        pure
-        returns (bytes32 remoteToken, string memory name, string memory symbol, uint8 decimals)
-    {
-        remoteToken = bytes32(seed);
-        name = string(abi.encodePacked("Token", vm.toString(seed)));
-        symbol = string(abi.encodePacked("TK", vm.toString(seed)));
-        decimals = uint8(seed % 19); // 0-18 decimals
     }
 }

--- a/solana/programs/bridge/src/solana_to_base/constants.rs
+++ b/solana/programs/bridge/src/solana_to_base/constants.rs
@@ -27,7 +27,7 @@ pub const SCALER_EXPONENT_METADATA_KEY: &str = "scaler_exponent";
 pub const GAS_FEE_RECEIVER: Pubkey = TRUSTED_ORACLE;
 
 #[constant]
-pub const MAX_CALL_BUFFER_SIZE: usize = 64 * 1024; // 64KB max size for call buffer data
+pub const MAX_CALL_BUFFER_SIZE: usize = 8 * 1024; // 8kb max size for call buffer data
 
 #[cfg(test)]
 mod tests {

--- a/solana/programs/bridge/src/solana_to_base/instructions/buffered/initialize_call_buffer.rs
+++ b/solana/programs/bridge/src/solana_to_base/instructions/buffered/initialize_call_buffer.rs
@@ -51,7 +51,7 @@ pub fn initialize_call_buffer_handler(
 
 #[error_code]
 pub enum InitializeCallBufferError {
-    #[msg("Call buffer size exceeds maximum allowed size of 64KB")]
+    #[msg("Call buffer size exceeds maximum allowed size")]
     MaxSizeExceeded,
 }
 
@@ -139,68 +139,66 @@ mod tests {
         assert_eq!(call_buffer_data.data, initial_data);
     }
 
-    // TODO: Uncomment once we implemented proper realloc to allow reaching the max size
-    //       https://stackoverflow.com/a/70156099
-    // #[test]
-    // fn test_initialize_call_buffer_max_size_exceeded() {
-    //     let (mut svm, _payer, _bridge_pda) = setup_bridge_and_svm();
+    #[test]
+    fn test_initialize_call_buffer_max_size_exceeded() {
+        let (mut svm, _payer, _bridge_pda) = setup_bridge_and_svm();
 
-    //     // Create payer account
-    //     let payer = Keypair::new();
-    //     svm.airdrop(&payer.pubkey(), LAMPORTS_PER_SOL).unwrap();
+        // Create payer account
+        let payer = Keypair::new();
+        svm.airdrop(&payer.pubkey(), LAMPORTS_PER_SOL).unwrap();
 
-    //     // Create call buffer account
-    //     let call_buffer = Keypair::new();
+        // Create call buffer account
+        let call_buffer = Keypair::new();
 
-    //     // Test parameters with max_data_len exceeding MAX_CALL_BUFFER_SIZE
-    //     let ty = CallType::Call;
-    //     let to = [1u8; 20];
-    //     let value = 0u128;
-    //     let initial_data = vec![0x12, 0x34];
-    //     let max_data_len = MAX_CALL_BUFFER_SIZE + 1; // Exceed the limit
+        // Test parameters with max_data_len exceeding MAX_CALL_BUFFER_SIZE
+        let ty = CallType::Call;
+        let to = [1u8; 20];
+        let value = 0u128;
+        let initial_data = vec![0x12, 0x34];
+        let max_data_len = MAX_CALL_BUFFER_SIZE + 1; // Exceed the limit
 
-    //     // Build the InitializeCallBuffer instruction accounts
-    //     let accounts = accounts::InitializeCallBuffer {
-    //         payer: payer.pubkey(),
-    //         call_buffer: call_buffer.pubkey(),
-    //         system_program: system_program::ID,
-    //     }
-    //     .to_account_metas(None);
+        // Build the InitializeCallBuffer instruction accounts
+        let accounts = accounts::InitializeCallBuffer {
+            payer: payer.pubkey(),
+            call_buffer: call_buffer.pubkey(),
+            system_program: system_program::ID,
+        }
+        .to_account_metas(None);
 
-    //     // Build the InitializeCallBuffer instruction
-    //     let ix = Instruction {
-    //         program_id: ID,
-    //         accounts,
-    //         data: InitializeCallBufferIx {
-    //             ty,
-    //             to,
-    //             value,
-    //             initial_data,
-    //             max_data_len,
-    //         }
-    //         .data(),
-    //     };
+        // Build the InitializeCallBuffer instruction
+        let ix = Instruction {
+            program_id: ID,
+            accounts,
+            data: InitializeCallBufferIx {
+                ty,
+                to,
+                value,
+                initial_data,
+                max_data_len,
+            }
+            .data(),
+        };
 
-    //     // Build the transaction
-    //     let tx = Transaction::new(
-    //         &[&payer, &call_buffer],
-    //         Message::new(&[ix], Some(&payer.pubkey())),
-    //         svm.latest_blockhash(),
-    //     );
+        // Build the transaction
+        let tx = Transaction::new(
+            &[&payer, &call_buffer],
+            Message::new(&[ix], Some(&payer.pubkey())),
+            svm.latest_blockhash(),
+        );
 
-    //     // Send the transaction - should fail
-    //     let result = svm.send_transaction(tx);
-    //     assert!(
-    //         result.is_err(),
-    //         "Expected transaction to fail with max size exceeded"
-    //     );
+        // Send the transaction - should fail
+        let result = svm.send_transaction(tx);
+        assert!(
+            result.is_err(),
+            "Expected transaction to fail with max size exceeded"
+        );
 
-    //     // Check that the error contains the expected error message
-    //     let error_string = format!("{:?}", result.unwrap_err());
-    //     assert!(
-    //         error_string.contains("MaxSizeExceeded"),
-    //         "Expected MaxSizeExceeded error, got: {}",
-    //         error_string
-    //     );
-    // }
+        // Check that the error contains the expected error message
+        let error_string = format!("{:?}", result.unwrap_err());
+        assert!(
+            error_string.contains("MaxSizeExceeded"),
+            "Expected MaxSizeExceeded error, got: {}",
+            error_string
+        );
+    }
 }

--- a/solana/programs/bridge/src/solana_to_base/instructions/mod.rs
+++ b/solana/programs/bridge/src/solana_to_base/instructions/mod.rs
@@ -97,8 +97,8 @@ fn min_gas_limit(tx_size: usize) -> u64 {
 
     // Buffers to account for the gas used in the `Bridge.__validateAndRelay` function.
     // See `Bridge.sol` for more details.
-    const EXECUTION_PROLOGUE_GAS_BUFFER: u64 = 65_000;
-    const EXECUTION_GAS_BUFFER: u64 = 40_000;
+    const EXECUTION_PROLOGUE_GAS_BUFFER: u64 = 20_000;
+    const EXECUTION_GAS_BUFFER: u64 = 5_000;
     const EXECUTION_EPILOGUE_GAS_BUFFER: u64 = 25_000;
 
     tx_size as u64 * 40


### PR DESCRIPTION
Reduce `CallBuffer.data` size limit to 8Kb as an immediate solution for https://github.com/base/bridge/pull/39.