### PR TITLE
fix(CHAIN-1864): accept paused status as input param

### DIFF
--- a/base/src/Bridge.sol
+++ b/base/src/Bridge.sol
@@ -230,9 +230,11 @@ contract Bridge is ReentrancyGuardTransient, Initializable, OwnableRoles {
     /// @notice Pauses or unpauses the bridge.
     ///
     /// @dev This function can only be called by a guardian.
-    function pauseSwitch() external onlyRoles(GUARDIAN_ROLE) {
-        paused = !paused;
-        emit PauseSwitched(paused);
+    ///
+    /// @param isPaused Boolean representing the desired paused status
+    function setPaused(bool isPaused) external onlyRoles(GUARDIAN_ROLE) {
+        paused = isPaused;
+        emit PauseSwitched(isPaused);
     }
 
     /// @notice Get the current root of the MMR.

--- a/base/test/Bridge.t.sol
+++ b/base/test/Bridge.t.sol
@@ -705,9 +705,9 @@ contract BridgeTest is CommonTest {
     ///                  Pause Mechanism Tests                 ///
     //////////////////////////////////////////////////////////////
 
-    function test_pause_blocksBridgeOperations() public {
+    function test_setPaused_blocksBridgeOperations() public {
         vm.prank(cfg.guardians[0]);
-        bridge.pauseSwitch();
+        bridge.setPaused(true);
 
         assertTrue(bridge.paused(), "Bridge should be paused");
 
@@ -732,31 +732,31 @@ contract BridgeTest is CommonTest {
         bridge.bridgeToken{value: 1e18}(transfer, new Ix[](0));
     }
 
-    function test_pauseSwitch_onlyGuardian() public {
+    function test_setPaused_onlyGuardian() public {
         // Test that non-guardian cannot pause
         vm.expectRevert();
         vm.prank(user);
-        bridge.pauseSwitch();
+        bridge.setPaused(true);
 
         assertFalse(bridge.paused(), "Bridge should start unpaused");
 
         // Guardian can pause
         vm.prank(cfg.guardians[0]);
-        bridge.pauseSwitch();
+        bridge.setPaused(true);
         assertTrue(bridge.paused(), "Bridge should be paused after guardian toggle");
 
         // Guardian can unpause
         vm.prank(cfg.guardians[0]);
-        bridge.pauseSwitch();
+        bridge.setPaused(false);
         assertFalse(bridge.paused(), "Bridge should be unpaused after second guardian toggle");
     }
 
-    function test_pause_worksNormallyWhenUnpaused() public {
+    function test_setPaused_worksNormallyWhenUnpaused() public {
         vm.prank(cfg.guardians[0]);
-        bridge.pauseSwitch(); // Pause
+        bridge.setPaused(true); // Pause
 
         vm.prank(cfg.guardians[0]);
-        bridge.pauseSwitch(); // Unpause
+        bridge.setPaused(false); // Unpause
 
         assertFalse(bridge.paused(), "Bridge should be unpaused");
 


### PR DESCRIPTION
Fixes: `Bridge.pauseSwitch()` always changes the pause status, which can lead to a coordination issue. For example, if 2 guardians both try to pause the bridge, the bridge will be unpaused by the 2 calls. Maybe better to require a boolean input