### PR TITLE
fix(CHAIN-1866): use require statements for reverts

### DIFF
--- a/base/src/Twin.sol
+++ b/base/src/Twin.sol
@@ -82,7 +82,7 @@ contract Twin {
     ///
     /// @param call The encoded call to execute, containing the call type, target, value, and data.
     function execute(Call calldata call) external payable {
-        if (msg.sender != BRIDGE && msg.sender != address(this)) revert Unauthorized();
+        require(msg.sender == BRIDGE || msg.sender == address(this), Unauthorized());
         CallLib.execute(call);
     }
 }

--- a/base/src/libraries/CallLib.sol
+++ b/base/src/libraries/CallLib.sol
@@ -38,17 +38,11 @@ library CallLib {
     function execute(Call memory call) internal {
         if (call.ty == CallType.Call) {
             (bool success, bytes memory result) = call.to.call{value: call.value}(call.data);
-
-            if (!success) {
-                revert(string(result));
-            }
+            require(success, string(result));
         } else if (call.ty == CallType.DelegateCall) {
-            if (call.value != 0) revert DelegateCallCannotHaveValue();
-
+            require(call.value == 0, DelegateCallCannotHaveValue());
             (bool success, bytes memory result) = call.to.delegatecall(call.data);
-            if (!success) {
-                revert(string(result));
-            }
+            require(success, string(result));
         } else if (call.ty == CallType.Create) {
             uint128 value = call.value;
             bytes memory data = call.data;

--- a/base/src/libraries/MessageStorageLib.sol
+++ b/base/src/libraries/MessageStorageLib.sol
@@ -93,13 +93,8 @@ library MessageStorageLib {
     function generateProof(uint64 leafIndex) internal view returns (bytes32[] memory proof, uint64 totalLeafCount) {
         MessageStorageLibStorage storage $ = getMessageStorageLibStorage();
 
-        if ($.lastOutgoingNonce == 0) {
-            revert EmptyMMR();
-        }
-
-        if (leafIndex >= $.lastOutgoingNonce) {
-            revert LeafIndexOutOfBounds();
-        }
+        require($.lastOutgoingNonce != 0, EmptyMMR());
+        require(leafIndex < $.lastOutgoingNonce, LeafIndexOutOfBounds());
 
         // Use optimized single-pass algorithm
         (uint256 leafNodePos, uint256 mountainHeight, uint64 leafIdxInMountain, bytes32[] memory otherPeaks) =
@@ -123,9 +118,7 @@ library MessageStorageLib {
                 siblingNodePos = parentNodePos - 1;
             }
 
-            if (siblingNodePos >= $.nodes.length) {
-                revert SiblingNodeOutOfBounds();
-            }
+            require(siblingNodePos < $.nodes.length, SiblingNodeOutOfBounds());
 
             intraMountainProof[hClimb] = $.nodes[siblingNodePos];
             currentPathNodePos = parentNodePos;


### PR DESCRIPTION
Fixes: Some areas use `require` while others use the `if ... revert` pattern