### PR TITLE
fix(CHAIN-1876): track deposits mapping for native ETH bridging

### DIFF
--- a/base/src/libraries/TokenLib.sol
+++ b/base/src/libraries/TokenLib.sol
@@ -132,6 +132,7 @@ library TokenLib {
             require(msg.value == localAmount, InvalidMsgValue());
 
             tokenType = SolanaTokenType.WrappedToken;
+            $.deposits[transfer.localToken][transfer.remoteToken] += localAmount;
         } else {
             // Prevent sending ETH when bridging ERC20 tokens
             require(msg.value == 0, InvalidMsgValue());
@@ -204,6 +205,7 @@ library TokenLib {
             uint256 scalar = $.scalars[transfer.localToken][transfer.remoteToken];
             require(scalar != 0, WrappedSplRouteNotRegistered());
             localAmount = transfer.remoteAmount * scalar;
+            $.deposits[transfer.localToken][transfer.remoteToken] -= localAmount;
 
             SafeTransferLib.safeTransferETH({to: to, amount: localAmount});
         } else {

--- a/base/test/Bridge.t.sol
+++ b/base/test/Bridge.t.sol
@@ -719,7 +719,9 @@ contract BridgeTest is CommonTest {
     //////////////////////////////////////////////////////////////
 
     function testFuzz_bridgeCall_withDifferentSenders(address sender) public {
+        // Avoid senders that may interact strangely with the transparent proxy routing
         vm.assume(sender != address(0));
+        vm.assume(sender != cfg.erc1967Factory);
 
         Ix[] memory ixs = new Ix[](1);
         ixs[0] = Ix({programId: TEST_SENDER, serializedAccounts: new bytes[](0), data: abi.encodePacked("test")});


### PR DESCRIPTION
Fixes: We don't update the `deposits` mapping for native ETH deposits/withdrawals. It can be useful for more granular monitoring, like associating an amount of locked ETH with a specific Solana token, rather than only being able to check the entire ETH balance