### PR TITLE
fix(CHAIN-1872): ensure wrapped token mint pubkeys are owned by bridge

### DIFF
--- a/solana/programs/bridge/src/base_to_solana/instructions/token/finalize_wrapped_token_transfer.rs
+++ b/solana/programs/bridge/src/base_to_solana/instructions/token/finalize_wrapped_token_transfer.rs
@@ -72,7 +72,14 @@ impl FinalizeBridgeWrappedToken {
             decimals_bytes.as_ref(),
             metadata_hash.as_ref(),
         ];
-        let (_, mint_bump) = Pubkey::find_program_address(seeds, &ID);
+        let (expected_mint_pda, mint_bump) = Pubkey::find_program_address(seeds, &ID);
+
+        // Ensure the mint account is the expected wrapped token PDA
+        require_keys_eq!(
+            mint.key(),
+            expected_mint_pda,
+            FinalizeBridgeWrappedTokenError::MintIsNotWrappedTokenPda
+        );
 
         let seeds: &[&[&[u8]]] = &[&[
             WRAPPED_TOKEN_SEED,
@@ -103,4 +110,6 @@ pub enum FinalizeBridgeWrappedTokenError {
     TokenAccountDoesNotMatchTo,
     #[msg("Mint does not match local token")]
     MintDoesNotMatchLocalToken,
+    #[msg("Mint is not a valid wrapped token PDA")]
+    MintIsNotWrappedTokenPda,
 }

--- a/solana/programs/bridge/src/solana_to_base/internal/bridge_wrapped_token.rs
+++ b/solana/programs/bridge/src/solana_to_base/internal/bridge_wrapped_token.rs
@@ -6,8 +6,9 @@ use anchor_spl::{
 
 use crate::solana_to_base::{check_call, pay_for_gas};
 use crate::{
-    common::{bridge::Bridge, PartialTokenMetadata},
+    common::{bridge::Bridge, PartialTokenMetadata, WRAPPED_TOKEN_SEED},
     solana_to_base::{Call, OutgoingMessage, Transfer as TransferOp},
+    ID,
 };
 
 #[allow(clippy::too_many_arguments)]
@@ -31,6 +32,21 @@ pub fn bridge_wrapped_token_internal<'info>(
 
     // Get the token metadata from the mint.
     let partial_token_metadata = PartialTokenMetadata::try_from(&mint.to_account_info())?;
+
+    // Ensure the provided mint is a PDA derived by this program for wrapped tokens.
+    let decimals_bytes = mint.decimals.to_le_bytes();
+    let metadata_hash = partial_token_metadata.hash();
+    let seeds: &[&[u8]] = &[
+        WRAPPED_TOKEN_SEED,
+        decimals_bytes.as_ref(),
+        metadata_hash.as_ref(),
+    ];
+    let (expected_mint, _bump) = Pubkey::find_program_address(seeds, &ID);
+    require_keys_eq!(
+        mint.key(),
+        expected_mint,
+        BridgeWrappedTokenInternalError::IncorrectWrappedMint
+    );
 
     let message = OutgoingMessage::new_transfer(
         bridge.nonce,
@@ -61,4 +77,10 @@ pub fn bridge_wrapped_token_internal<'info>(
     bridge.nonce += 1;
 
     Ok(())
+}
+
+#[error_code]
+pub enum BridgeWrappedTokenInternalError {
+    #[msg("Mint is not a valid wrapped token PDA")]
+    IncorrectWrappedMint,
 }


### PR DESCRIPTION
Fixes: The mint accounts in `bridge_wrapped_token_internal` and `FinalizeBridgeWrappedToken::finalize` do not have PDA checks. A check ensures a token created by our bridge is used