### PR TITLE
chore(solana): allocate exact space for messages

### DIFF
--- a/solana/programs/bridge/src/solana_to_base/instructions/bridge_call.rs
+++ b/solana/programs/bridge/src/solana_to_base/instructions/bridge_call.rs
@@ -43,7 +43,7 @@ pub struct BridgeCall<'info> {
     #[account(
         init,
         payer = payer,
-        space = 8 + OutgoingMessage::space::<Call>(Some(call.data.len())),
+        space = 8 + OutgoingMessage::space::<Call>(call.data.len()),
     )]
     pub outgoing_message: Account<'info, OutgoingMessage>,
 

--- a/solana/programs/bridge/src/solana_to_base/instructions/bridge_call.rs
+++ b/solana/programs/bridge/src/solana_to_base/instructions/bridge_call.rs
@@ -43,7 +43,7 @@ pub struct BridgeCall<'info> {
     #[account(
         init,
         payer = payer,
-        space = 8 + OutgoingMessage::space(Some(call.data.len())),
+        space = 8 + OutgoingMessage::space::<Call>(Some(call.data.len())),
     )]
     pub outgoing_message: Account<'info, OutgoingMessage>,
 

--- a/solana/programs/bridge/src/solana_to_base/instructions/bridge_sol.rs
+++ b/solana/programs/bridge/src/solana_to_base/instructions/bridge_sol.rs
@@ -2,7 +2,7 @@ use anchor_lang::prelude::*;
 
 use crate::{
     common::{bridge::Bridge, BRIDGE_SEED, SOL_VAULT_SEED},
-    solana_to_base::{internal::bridge_sol::bridge_sol_internal, Call, OutgoingMessage},
+    solana_to_base::{internal::bridge_sol::bridge_sol_internal, Call, OutgoingMessage, Transfer},
 };
 
 /// Accounts struct for the bridge_sol instruction that transfers native SOL from Solana to Base
@@ -54,7 +54,7 @@ pub struct BridgeSol<'info> {
     #[account(
         init,
         payer = payer,
-        space = 8 + OutgoingMessage::space(call.as_ref().map(|c| c.data.len())),
+        space = 8 + OutgoingMessage::space::<Transfer>(call.as_ref().map(|c| c.data.len())),
     )]
     pub outgoing_message: Account<'info, OutgoingMessage>,
 

--- a/solana/programs/bridge/src/solana_to_base/instructions/bridge_sol.rs
+++ b/solana/programs/bridge/src/solana_to_base/instructions/bridge_sol.rs
@@ -54,7 +54,7 @@ pub struct BridgeSol<'info> {
     #[account(
         init,
         payer = payer,
-        space = 8 + OutgoingMessage::space::<Transfer>(call.as_ref().map(|c| c.data.len())),
+        space = 8 + OutgoingMessage::space::<Transfer>(call.map(|c| c.data.len()).unwrap_or_default()),
     )]
     pub outgoing_message: Account<'info, OutgoingMessage>,
 

--- a/solana/programs/bridge/src/solana_to_base/instructions/bridge_spl.rs
+++ b/solana/programs/bridge/src/solana_to_base/instructions/bridge_spl.rs
@@ -72,7 +72,7 @@ pub struct BridgeSpl<'info> {
     #[account(
         init,
         payer = payer,
-        space = 8 + OutgoingMessage::space::<Transfer>(call.as_ref().map(|c| c.data.len())),
+        space = 8 + OutgoingMessage::space::<Transfer>(call.as_ref().map(|c| c.data.len()).unwrap_or_default()),
     )]
     pub outgoing_message: Account<'info, OutgoingMessage>,
 

--- a/solana/programs/bridge/src/solana_to_base/instructions/bridge_spl.rs
+++ b/solana/programs/bridge/src/solana_to_base/instructions/bridge_spl.rs
@@ -3,7 +3,7 @@ use anchor_spl::token_interface::{Mint, TokenAccount, TokenInterface};
 
 use crate::{
     common::{bridge::Bridge, BRIDGE_SEED, TOKEN_VAULT_SEED},
-    solana_to_base::{internal::bridge_spl::bridge_spl_internal, Call, OutgoingMessage},
+    solana_to_base::{internal::bridge_spl::bridge_spl_internal, Call, OutgoingMessage, Transfer},
 };
 
 /// Accounts struct for the bridge_spl instruction that transfers SPL tokens from Solana to Base along
@@ -72,7 +72,7 @@ pub struct BridgeSpl<'info> {
     #[account(
         init,
         payer = payer,
-        space = 8 + OutgoingMessage::space(call.as_ref().map(|c| c.data.len())),
+        space = 8 + OutgoingMessage::space::<Transfer>(call.as_ref().map(|c| c.data.len())),
     )]
     pub outgoing_message: Account<'info, OutgoingMessage>,
 

--- a/solana/programs/bridge/src/solana_to_base/instructions/bridge_wrapped_token.rs
+++ b/solana/programs/bridge/src/solana_to_base/instructions/bridge_wrapped_token.rs
@@ -7,7 +7,7 @@ use anchor_spl::{
 use crate::{
     common::{bridge::Bridge, BRIDGE_SEED},
     solana_to_base::{
-        internal::bridge_wrapped_token::bridge_wrapped_token_internal, Call, OutgoingMessage,
+        internal::bridge_wrapped_token::bridge_wrapped_token_internal, Call, OutgoingMessage, Transfer,
     },
 };
 
@@ -58,7 +58,7 @@ pub struct BridgeWrappedToken<'info> {
     #[account(
         init,       
         payer = payer,
-        space = 8 + OutgoingMessage::space(call.as_ref().map(|c| c.data.len())),
+        space = 8 + OutgoingMessage::space::<Transfer>(call.as_ref().map(|c| c.data.len())),
     )]
     pub outgoing_message: Account<'info, OutgoingMessage>,
 

--- a/solana/programs/bridge/src/solana_to_base/instructions/bridge_wrapped_token.rs
+++ b/solana/programs/bridge/src/solana_to_base/instructions/bridge_wrapped_token.rs
@@ -58,7 +58,7 @@ pub struct BridgeWrappedToken<'info> {
     #[account(
         init,       
         payer = payer,
-        space = 8 + OutgoingMessage::space::<Transfer>(call.as_ref().map(|c| c.data.len())),
+        space = 8 + OutgoingMessage::space::<Transfer>(call.as_ref().map(|c| c.data.len()).unwrap_or_default()),
     )]
     pub outgoing_message: Account<'info, OutgoingMessage>,
 

--- a/solana/programs/bridge/src/solana_to_base/instructions/buffered/bridge_call.rs
+++ b/solana/programs/bridge/src/solana_to_base/instructions/buffered/bridge_call.rs
@@ -59,7 +59,7 @@ pub struct BridgeCallBuffered<'info> {
     #[account(
         init,
         payer = payer,
-        space = 8 + OutgoingMessage::space(Some(call_buffer.data.len())),
+        space = 8 + OutgoingMessage::space::<Call>(Some(call_buffer.data.len())),
     )]
     pub outgoing_message: Account<'info, OutgoingMessage>,
 

--- a/solana/programs/bridge/src/solana_to_base/instructions/buffered/bridge_call.rs
+++ b/solana/programs/bridge/src/solana_to_base/instructions/buffered/bridge_call.rs
@@ -59,7 +59,7 @@ pub struct BridgeCallBuffered<'info> {
     #[account(
         init,
         payer = payer,
-        space = 8 + OutgoingMessage::space::<Call>(Some(call_buffer.data.len())),
+        space = 8 + OutgoingMessage::space::<Call>(call_buffer.data.len()),
     )]
     pub outgoing_message: Account<'info, OutgoingMessage>,
 

--- a/solana/programs/bridge/src/solana_to_base/instructions/buffered/bridge_sol.rs
+++ b/solana/programs/bridge/src/solana_to_base/instructions/buffered/bridge_sol.rs
@@ -3,7 +3,7 @@ use anchor_lang::prelude::*;
 use crate::{
     common::{bridge::Bridge, BRIDGE_SEED, SOL_VAULT_SEED},
     solana_to_base::{
-        internal::bridge_sol::bridge_sol_internal, Call, CallBuffer, OutgoingMessage,
+        internal::bridge_sol::bridge_sol_internal, Call, CallBuffer, OutgoingMessage, Transfer,
     },
 };
 
@@ -68,7 +68,7 @@ pub struct BridgeSolWithBufferedCall<'info> {
     /// - Created fresh for each bridge; address determined by the provided keypair
     /// - Funded by `payer`
     /// - Space: 8-byte Anchor discriminator + serialized `OutgoingMessage`
-    #[account(init, payer = payer, space = 8 + OutgoingMessage::space(Some(call_buffer.data.len())))]
+    #[account(init, payer = payer, space = 8 + OutgoingMessage::space::<Transfer>(Some(call_buffer.data.len())))]
     pub outgoing_message: Account<'info, OutgoingMessage>,
 
     /// System program required for account creation and the SOL transfer CPI.

--- a/solana/programs/bridge/src/solana_to_base/instructions/buffered/bridge_sol.rs
+++ b/solana/programs/bridge/src/solana_to_base/instructions/buffered/bridge_sol.rs
@@ -68,7 +68,7 @@ pub struct BridgeSolWithBufferedCall<'info> {
     /// - Created fresh for each bridge; address determined by the provided keypair
     /// - Funded by `payer`
     /// - Space: 8-byte Anchor discriminator + serialized `OutgoingMessage`
-    #[account(init, payer = payer, space = 8 + OutgoingMessage::space::<Transfer>(Some(call_buffer.data.len())))]
+    #[account(init, payer = payer, space = 8 + OutgoingMessage::space::<Transfer>(call_buffer.data.len()))]
     pub outgoing_message: Account<'info, OutgoingMessage>,
 
     /// System program required for account creation and the SOL transfer CPI.

--- a/solana/programs/bridge/src/solana_to_base/instructions/buffered/bridge_spl.rs
+++ b/solana/programs/bridge/src/solana_to_base/instructions/buffered/bridge_spl.rs
@@ -84,7 +84,7 @@ pub struct BridgeSplWithBufferedCall<'info> {
     #[account(
         init,
         payer = payer,
-        space = 8 + OutgoingMessage::space::<Transfer>(Some(call_buffer.data.len())),
+        space = 8 + OutgoingMessage::space::<Transfer>(call_buffer.data.len()),
     )]
     pub outgoing_message: Account<'info, OutgoingMessage>,
 

--- a/solana/programs/bridge/src/solana_to_base/instructions/buffered/bridge_spl.rs
+++ b/solana/programs/bridge/src/solana_to_base/instructions/buffered/bridge_spl.rs
@@ -4,7 +4,7 @@ use anchor_spl::token_interface::{Mint, TokenAccount, TokenInterface};
 use crate::{
     common::{bridge::Bridge, BRIDGE_SEED, TOKEN_VAULT_SEED},
     solana_to_base::{
-        internal::bridge_spl::bridge_spl_internal, Call, CallBuffer, OutgoingMessage,
+        internal::bridge_spl::bridge_spl_internal, Call, CallBuffer, OutgoingMessage, Transfer,
     },
 };
 
@@ -84,7 +84,7 @@ pub struct BridgeSplWithBufferedCall<'info> {
     #[account(
         init,
         payer = payer,
-        space = 8 + OutgoingMessage::space(Some(call_buffer.data.len())),
+        space = 8 + OutgoingMessage::space::<Transfer>(Some(call_buffer.data.len())),
     )]
     pub outgoing_message: Account<'info, OutgoingMessage>,
 

--- a/solana/programs/bridge/src/solana_to_base/instructions/buffered/bridge_wrapped_token.rs
+++ b/solana/programs/bridge/src/solana_to_base/instructions/buffered/bridge_wrapped_token.rs
@@ -74,7 +74,7 @@ pub struct BridgeWrappedTokenWithBufferedCall<'info> {
     #[account(
         init,
         payer = payer,
-        space = 8 + OutgoingMessage::space::<Transfer>(Some(call_buffer.data.len())),
+        space = 8 + OutgoingMessage::space::<Transfer>(call_buffer.data.len()),
     )]
     pub outgoing_message: Account<'info, OutgoingMessage>,
 

--- a/solana/programs/bridge/src/solana_to_base/instructions/buffered/bridge_wrapped_token.rs
+++ b/solana/programs/bridge/src/solana_to_base/instructions/buffered/bridge_wrapped_token.rs
@@ -8,7 +8,7 @@ use crate::{
     common::{bridge::Bridge, BRIDGE_SEED},
     solana_to_base::{
         internal::bridge_wrapped_token::bridge_wrapped_token_internal, Call, CallBuffer,
-        OutgoingMessage,
+        OutgoingMessage, Transfer,
     },
 };
 
@@ -74,7 +74,7 @@ pub struct BridgeWrappedTokenWithBufferedCall<'info> {
     #[account(
         init,
         payer = payer,
-        space = 8 + OutgoingMessage::space(Some(call_buffer.data.len())),
+        space = 8 + OutgoingMessage::space::<Transfer>(Some(call_buffer.data.len())),
     )]
     pub outgoing_message: Account<'info, OutgoingMessage>,
 

--- a/solana/programs/bridge/src/solana_to_base/instructions/wrap_token.rs
+++ b/solana/programs/bridge/src/solana_to_base/instructions/wrap_token.rs
@@ -72,7 +72,7 @@ pub struct WrapToken<'info> {
     #[account(
         init,
         payer = payer,
-        space = 8 + OutgoingMessage::space::<Call>(Some(REGISTER_REMOTE_TOKEN_DATA_LEN)),
+        space = 8 + OutgoingMessage::space::<Call>(REGISTER_REMOTE_TOKEN_DATA_LEN),
     )]
     pub outgoing_message: Account<'info, OutgoingMessage>,
 

--- a/solana/programs/bridge/src/solana_to_base/instructions/wrap_token.rs
+++ b/solana/programs/bridge/src/solana_to_base/instructions/wrap_token.rs
@@ -72,7 +72,7 @@ pub struct WrapToken<'info> {
     #[account(
         init,
         payer = payer,
-        space = 8 + OutgoingMessage::space(Some(REGISTER_REMOTE_TOKEN_DATA_LEN)),
+        space = 8 + OutgoingMessage::space::<Call>(Some(REGISTER_REMOTE_TOKEN_DATA_LEN)),
     )]
     pub outgoing_message: Account<'info, OutgoingMessage>,
 

--- a/solana/programs/bridge/src/solana_to_base/state/outgoing_message.rs
+++ b/solana/programs/bridge/src/solana_to_base/state/outgoing_message.rs
@@ -1,5 +1,10 @@
 use anchor_lang::prelude::*;
 
+/// Trait for calculating the space required for a message.
+pub trait MessageSpace {
+    fn space(data_len: Option<usize>) -> usize;
+}
+
 /// Represents a token transfer from Solana to Base with optional contract execution.
 /// This struct contains all the information needed to bridge tokens between chains
 /// and optionally execute additional logic on the destination chain after the transfer.
@@ -26,13 +31,13 @@ pub struct Transfer {
     pub call: Option<Call>,
 }
 
-impl Transfer {
-    pub fn space(data_len: Option<usize>) -> usize {
+impl MessageSpace for Transfer {
+    fn space(data_len: Option<usize>) -> usize {
         20 + // to
         32 + // local_token
         20 + // remote_token
         8 + // amount
-        1 + Call::space(data_len.unwrap_or_default()) // option_flag + call
+        1 + Call::space(data_len) // option_flag + call
     }
 }
 
@@ -66,12 +71,12 @@ pub struct Call {
     pub data: Vec<u8>,
 }
 
-impl Call {
-    pub fn space(data_len: usize) -> usize {
+impl MessageSpace for Call {
+    fn space(data_len: Option<usize>) -> usize {
         CallType::INIT_SPACE + // call type
         20 + // to
         16 + // value
-        4 + data_len // len_prefix + data
+        4 + data_len.unwrap_or_default() // len_prefix + data
     }
 }
 
@@ -129,11 +134,9 @@ impl OutgoingMessage {
     /// Returns the serialized size of an `OutgoingMessage` payload, excluding the 8-byte Anchor
     /// account discriminator. Uses the `Transfer` variant for sizing because it is larger than
     /// `Call` (it embeds an optional `Call`), ensuring sufficient capacity for either variant.
-    pub fn space(data_len: Option<usize>) -> usize {
+    pub fn space<T: MessageSpace>(data_len: Option<usize>) -> usize {
         8 + // nonce
         32 + // sender
-
-        // TODO: Accept the message type as a parameter, so we can use the correct space calculation.
-        1 + Transfer::space(data_len) // variant + transfer (the transfer variant is always bigger as it embeds an optional call)
+        1 + T::space(data_len) // variant + transfer (the transfer variant is always bigger as it embeds an optional call)
     }
 }

--- a/solana/programs/bridge/src/solana_to_base/state/outgoing_message.rs
+++ b/solana/programs/bridge/src/solana_to_base/state/outgoing_message.rs
@@ -136,6 +136,6 @@ impl OutgoingMessage {
     pub fn space<T: MessageSpace>(data_len: usize) -> usize {
         8 + // nonce
         32 + // sender
-        1 + T::space(data_len) // variant + transfer
+        1 + T::space(data_len) // message (variant + space)
     }
 }

--- a/solana/programs/bridge/src/solana_to_base/state/outgoing_message.rs
+++ b/solana/programs/bridge/src/solana_to_base/state/outgoing_message.rs
@@ -132,11 +132,10 @@ impl OutgoingMessage {
     }
 
     /// Returns the serialized size of an `OutgoingMessage` payload, excluding the 8-byte Anchor
-    /// account discriminator. Uses the `Transfer` variant for sizing because it is larger than
-    /// `Call` (it embeds an optional `Call`), ensuring sufficient capacity for either variant.
+    /// account discriminator.
     pub fn space<T: MessageSpace>(data_len: usize) -> usize {
         8 + // nonce
         32 + // sender
-        1 + T::space(data_len) // variant + transfer (the transfer variant is always bigger as it embeds an optional call)
+        1 + T::space(data_len) // variant + transfer
     }
 }

--- a/solana/programs/bridge/src/solana_to_base/state/outgoing_message.rs
+++ b/solana/programs/bridge/src/solana_to_base/state/outgoing_message.rs
@@ -2,7 +2,7 @@ use anchor_lang::prelude::*;
 
 /// Trait for calculating the space required for a message.
 pub trait MessageSpace {
-    fn space(data_len: Option<usize>) -> usize;
+    fn space(data_len: usize) -> usize;
 }
 
 /// Represents a token transfer from Solana to Base with optional contract execution.
@@ -32,7 +32,7 @@ pub struct Transfer {
 }
 
 impl MessageSpace for Transfer {
-    fn space(data_len: Option<usize>) -> usize {
+    fn space(data_len: usize) -> usize {
         20 + // to
         32 + // local_token
         20 + // remote_token
@@ -72,11 +72,11 @@ pub struct Call {
 }
 
 impl MessageSpace for Call {
-    fn space(data_len: Option<usize>) -> usize {
+    fn space(data_len: usize) -> usize {
         CallType::INIT_SPACE + // call type
         20 + // to
         16 + // value
-        4 + data_len.unwrap_or_default() // len_prefix + data
+        4 + data_len // len_prefix + data
     }
 }
 
@@ -134,7 +134,7 @@ impl OutgoingMessage {
     /// Returns the serialized size of an `OutgoingMessage` payload, excluding the 8-byte Anchor
     /// account discriminator. Uses the `Transfer` variant for sizing because it is larger than
     /// `Call` (it embeds an optional `Call`), ensuring sufficient capacity for either variant.
-    pub fn space<T: MessageSpace>(data_len: Option<usize>) -> usize {
+    pub fn space<T: MessageSpace>(data_len: usize) -> usize {
         8 + // nonce
         32 + // sender
         1 + T::space(data_len) // variant + transfer (the transfer variant is always bigger as it embeds an optional call)


### PR DESCRIPTION
- Add `MessageSpace` trait implemented by `Transfer` and `Call`.
- Use the correct variant implementation when computing the overall `OutgoingMessage` space.