### PR TITLE
feat: add nonce tracking to relayer feature and other minor refactors

### DIFF
--- a/base/test/periphery/RelayerOrchestrator.t.sol
+++ b/base/test/periphery/RelayerOrchestrator.t.sol
@@ -44,17 +44,20 @@ contract RelayerOrchestratorTest is CommonTest {
         });
 
         // Build message aligned with current BridgeValidator nonce
-        IncomingMessage[] memory messages = new IncomingMessage[](1);
-        messages[0] = IncomingMessage({
-            nonce: uint64(bridgeValidator.nextNonce()),
-            sender: Pubkey.wrap(bytes32(uint256(0x01))),
-            gasLimit: GAS_LIMIT,
-            ty: MessageType.Call,
-            data: abi.encode(call_)
+        RelayerOrchestrator.MessageToExecute[] memory messages = new RelayerOrchestrator.MessageToExecute[](1);
+        messages[0] = RelayerOrchestrator.MessageToExecute({
+            nonce: relayerOrchestrator.nextNonce(),
+            message: IncomingMessage({
+                nonce: uint64(bridgeValidator.nextNonce()),
+                sender: Pubkey.wrap(bytes32(uint256(0x01))),
+                gasLimit: GAS_LIMIT,
+                ty: MessageType.Call,
+                data: abi.encode(call_)
+            })
         });
 
         // Compute inner message hash and corresponding validator signatures
-        (, bytes32[] memory innerMessageHashes) = _messageToMessageHashes(messages[0]);
+        (, bytes32[] memory innerMessageHashes) = _messageToMessageHashes(messages[0].message);
         bytes memory sigs = _getValidatorSigs(innerMessageHashes);
 
         // Call orchestrator
@@ -65,7 +68,7 @@ contract RelayerOrchestratorTest is CommonTest {
         // Effects: target updated, success recorded, nonce incremented
         assertEq(target.value(), newValue, "call not executed");
 
-        bytes32 msgHash = bridge.getMessageHash(messages[0]);
+        bytes32 msgHash = bridge.getMessageHash(messages[0].message);
         assertTrue(bridge.successes(msgHash), "message not marked success");
         assertEq(bridgeValidator.nextNonce(), uint256(messages[0].nonce) + 1, "nonce not incremented");
     }

--- a/solana/programs/base_relayer/src/instructions/initialize.rs
+++ b/solana/programs/base_relayer/src/instructions/initialize.rs
@@ -1,6 +1,10 @@
 use anchor_lang::prelude::*;
 
-use crate::{constants::CFG_SEED, Cfg};
+use crate::{
+    constants::CFG_SEED,
+    internal::{Eip1559, Eip1559Config, GasConfig},
+    Cfg,
+};
 
 #[derive(Accounts)]
 pub struct Initialize<'info> {
@@ -25,100 +29,24 @@ pub struct Initialize<'info> {
     pub system_program: Program<'info, System>,
 }
 
-pub fn initialize_handler(ctx: Context<Initialize>, cfg: Cfg) -> Result<()> {
-    // Delegate to a pure helper for easy unit testing without Anchor runtime
-    assign_cfg_fields(&mut ctx.accounts.cfg, &cfg);
+pub fn initialize_handler(
+    ctx: Context<Initialize>,
+    guardian: Pubkey,
+    eip1559_config: Eip1559Config,
+    gas_config: GasConfig,
+) -> Result<()> {
+    let current_timestamp = Clock::get()?.unix_timestamp;
+    let minimum_base_fee = eip1559_config.minimum_base_fee;
+
+    ctx.accounts.cfg.guardian = guardian;
+    ctx.accounts.cfg.eip1559 = Eip1559 {
+        config: eip1559_config,
+        current_base_fee: minimum_base_fee,
+        current_window_gas_used: 0,
+        window_start_time: current_timestamp,
+    };
+    ctx.accounts.cfg.gas_config = gas_config;
+    ctx.accounts.cfg.nonce = 0;
+
     Ok(())
-}
-
-/// Pure helper that applies the provided configuration onto the target state.
-/// This is kept separate so we can unit test it with plain Rust types.
-pub fn assign_cfg_fields(target: &mut Cfg, source: &Cfg) {
-    target.guardian = source.guardian;
-    target.eip1559 = source.eip1559.clone();
-    target.gas_config = source.gas_config.clone();
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::internal::{Eip1559, Eip1559Config, GasConfig};
-    use anchor_lang::prelude::Pubkey;
-
-    fn sample_eip1559_config(minimum_base_fee: u64) -> Eip1559 {
-        Eip1559 {
-            config: Eip1559Config {
-                target: 1_000_000,
-                denominator: 10,
-                window_duration_seconds: 60,
-                minimum_base_fee,
-            },
-            current_base_fee: minimum_base_fee,
-            current_window_gas_used: 0,
-            window_start_time: 0,
-        }
-    }
-
-    fn sample_gas_config(receiver: Pubkey) -> GasConfig {
-        GasConfig {
-            max_gas_limit_per_message: 10_000_000,
-            gas_cost_scaler: 1,
-            gas_cost_scaler_dp: 1,
-            gas_fee_receiver: receiver,
-        }
-    }
-
-    fn empty_cfg() -> Cfg {
-        Cfg {
-            guardian: Pubkey::default(),
-            eip1559: sample_eip1559_config(0),
-            gas_config: sample_gas_config(Pubkey::default()),
-        }
-    }
-
-    #[test]
-    fn assigns_guardian_from_source() {
-        let mut target = empty_cfg();
-        let new_guardian = Pubkey::new_unique();
-        let source = Cfg {
-            guardian: new_guardian,
-            eip1559: sample_eip1559_config(100),
-            gas_config: sample_gas_config(Pubkey::new_unique()),
-        };
-
-        assign_cfg_fields(&mut target, &source);
-
-        assert_eq!(target.guardian, new_guardian);
-    }
-
-    #[test]
-    fn assigns_eip1559_from_source() {
-        let mut target = empty_cfg();
-        let new_eip = sample_eip1559_config(123);
-        let source = Cfg {
-            guardian: Pubkey::new_unique(),
-            eip1559: new_eip.clone(),
-            gas_config: sample_gas_config(Pubkey::new_unique()),
-        };
-
-        assign_cfg_fields(&mut target, &source);
-
-        assert_eq!(target.eip1559, new_eip);
-    }
-
-    #[test]
-    fn assigns_gas_config_from_source() {
-        let mut target = empty_cfg();
-        let new_receiver = Pubkey::new_unique();
-        let new_gas = sample_gas_config(new_receiver);
-        let source = Cfg {
-            guardian: Pubkey::new_unique(),
-            eip1559: sample_eip1559_config(42),
-            gas_config: new_gas.clone(),
-        };
-
-        assign_cfg_fields(&mut target, &source);
-
-        assert_eq!(target.gas_config, new_gas);
-    }
 }

--- a/solana/programs/base_relayer/src/instructions/pay_for_relay.rs
+++ b/solana/programs/base_relayer/src/instructions/pay_for_relay.rs
@@ -46,6 +46,8 @@ pub fn pay_for_relay_handler(
     )?;
     ctx.accounts.message_to_relay.outgoing_message = outgoing_message;
     ctx.accounts.message_to_relay.gas_limit = gas_limit;
+    ctx.accounts.message_to_relay.nonce = ctx.accounts.cfg.nonce;
+    ctx.accounts.cfg.nonce += 1;
     Ok(())
 }
 
@@ -120,9 +122,6 @@ mod tests {
 
         // With base_fee = 1 in tests, gas_cost == gas_limit
         let final_receiver_balance = svm.get_account(&TEST_GAS_FEE_RECEIVER).unwrap().lamports;
-        assert_eq!(
-            final_receiver_balance - initial_receiver_balance,
-            gas_limit * 100
-        );
+        assert_eq!(final_receiver_balance - initial_receiver_balance, gas_limit);
     }
 }

--- a/solana/programs/base_relayer/src/internal/eip_1559.rs
+++ b/solana/programs/base_relayer/src/internal/eip_1559.rs
@@ -123,7 +123,12 @@ mod tests {
     use super::*;
 
     fn new_eip() -> Eip1559 {
-        Eip1559::test_new()
+        Eip1559 {
+            config: Eip1559Config::test_new(),
+            current_base_fee: 100,
+            current_window_gas_used: 0,
+            window_start_time: 0,
+        }
     }
 
     #[test]
@@ -212,9 +217,10 @@ mod tests {
     fn refresh_base_fee_no_expiry_keeps_start_time() {
         let eip = new_eip();
         let mut eip = Eip1559 { ..eip };
+        let start_time = eip.window_start_time;
         let _ = eip.refresh_base_fee(eip.window_start_time);
 
-        assert_eq!(eip.window_start_time, Eip1559::test_new().window_start_time);
+        assert_eq!(eip.window_start_time, start_time);
     }
 
     #[test]

--- a/solana/programs/base_relayer/src/internal/gas_config.rs
+++ b/solana/programs/base_relayer/src/internal/gas_config.rs
@@ -73,6 +73,7 @@ pub enum GasConfigError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::internal::{Eip1559, Eip1559Config};
     use crate::state::Cfg;
     use crate::test_utils::{mock_clock, setup_program_and_svm, TEST_GAS_FEE_RECEIVER};
     use crate::{accounts, instruction};
@@ -88,12 +89,22 @@ mod tests {
         Cfg::try_deserialize(&mut &account.data[..]).unwrap()
     }
 
+    fn new_eip() -> Eip1559 {
+        Eip1559 {
+            config: Eip1559Config::test_new(),
+            current_base_fee: 100,
+            current_window_gas_used: 0,
+            window_start_time: 0,
+        }
+    }
+
     #[test]
     fn check_gas_limit_allows_equal_limit() {
         let mut cfg = Cfg {
             guardian: Pubkey::new_unique(),
-            eip1559: crate::internal::Eip1559::test_new(),
+            eip1559: new_eip(),
             gas_config: GasConfig::test_new(TEST_GAS_FEE_RECEIVER),
+            nonce: 0,
         };
         cfg.gas_config.max_gas_limit_per_message = 100;
 
@@ -105,8 +116,9 @@ mod tests {
     fn check_gas_limit_errors_above_limit() {
         let mut cfg = Cfg {
             guardian: Pubkey::new_unique(),
-            eip1559: crate::internal::Eip1559::test_new(),
+            eip1559: new_eip(),
             gas_config: GasConfig::test_new(TEST_GAS_FEE_RECEIVER),
+            nonce: 0,
         };
         cfg.gas_config.max_gas_limit_per_message = 100;
 
@@ -138,7 +150,10 @@ mod tests {
         let ix = Instruction {
             program_id: crate::ID,
             accounts,
-            data: instruction::SetGasConfig { cfg: new_gas }.data(),
+            data: instruction::SetGasConfig {
+                gas_config: new_gas,
+            }
+            .data(),
         };
 
         let tx = Transaction::new(
@@ -178,7 +193,7 @@ mod tests {
         svm.send_transaction(tx).unwrap();
 
         let final_receiver_balance = svm.get_account(&TEST_GAS_FEE_RECEIVER).unwrap().lamports;
-        assert_eq!(final_receiver_balance - initial_receiver_balance, 246 * 100);
+        assert_eq!(final_receiver_balance - initial_receiver_balance, 246);
     }
 
     #[test]
@@ -213,12 +228,18 @@ mod tests {
         let ix = Instruction {
             program_id: crate::ID,
             accounts: accounts.clone(),
-            data: instruction::SetGasConfig { cfg: new_gas }.data(),
+            data: instruction::SetGasConfig {
+                gas_config: new_gas,
+            }
+            .data(),
         };
         let new_eip_ix = Instruction {
             program_id: crate::ID,
             accounts,
-            data: instruction::SetEip1559Config { cfg: new_eip }.data(),
+            data: instruction::SetEip1559Config {
+                eip1559_config: new_eip,
+            }
+            .data(),
         };
 
         let tx = Transaction::new(
@@ -260,12 +281,12 @@ mod tests {
         svm.send_transaction(tx).unwrap();
 
         let final_receiver_balance = svm.get_account(&TEST_GAS_FEE_RECEIVER).unwrap().lamports;
-        // base_fee 50 * gas_limit 1000 = 50_000
-        assert_eq!(final_receiver_balance - initial_receiver_balance, 50_000);
+        // base_fee 1 * gas_limit 1000 = 1_000
+        assert_eq!(final_receiver_balance - initial_receiver_balance, 1_000);
 
         // Validate EIP-1559 state was updated for the new window and usage accounted
         let updated = fetch_cfg(&svm, &cfg_pda);
-        assert_eq!(updated.eip1559.current_base_fee, 50);
+        assert_eq!(updated.eip1559.current_base_fee, 1);
         assert_eq!(updated.eip1559.current_window_gas_used, gas_limit);
         assert_eq!(updated.eip1559.window_start_time, start_time + 1);
     }

--- a/solana/programs/base_relayer/src/lib.rs
+++ b/solana/programs/base_relayer/src/lib.rs
@@ -19,8 +19,6 @@ declare_id!("4sW86ZszkmjoNLUrmWdNbsjC1DQhwBWX2a45nzjhCZpZ");
 #[program]
 pub mod base_relayer {
 
-    use crate::internal::Eip1559Config;
-
     use super::*;
 
     /// Initializes the Base relayer program configuration.
@@ -34,8 +32,13 @@ pub mod base_relayer {
     ///           is recorded as the admin authority.
     /// * `cfg` - Initial configuration values: guardian pubkey, EIP-1559 state and
     ///           config, and gas-cost configuration.
-    pub fn initialize(ctx: Context<Initialize>, cfg: Cfg) -> Result<()> {
-        initialize_handler(ctx, cfg)
+    pub fn initialize(
+        ctx: Context<Initialize>,
+        new_guardian: Pubkey,
+        eip1559_config: Eip1559Config,
+        gas_config: GasConfig,
+    ) -> Result<()> {
+        initialize_handler(ctx, new_guardian, eip1559_config, gas_config)
     }
 
     /// Updates the EIP1559 configuration.
@@ -45,8 +48,11 @@ pub mod base_relayer {
     /// * `ctx` - The context containing the `cfg` PDA and the `guardian` signer.
     ///           Authorization is enforced via an Anchor `has_one` constraint.
     /// * `cfg` - The new EIP1559 configuration to write in full.
-    pub fn set_eip1559_config(ctx: Context<SetConfig>, cfg: Eip1559Config) -> Result<()> {
-        set_eip1559_config_handler(ctx, cfg)
+    pub fn set_eip1559_config(
+        ctx: Context<SetConfig>,
+        eip1559_config: Eip1559Config,
+    ) -> Result<()> {
+        set_eip1559_config_handler(ctx, eip1559_config)
     }
 
     /// Updates the Gas configuration.
@@ -56,8 +62,8 @@ pub mod base_relayer {
     /// * `ctx` - The context containing the `cfg` PDA and the `guardian` signer.
     ///           Authorization is enforced via an Anchor `has_one` constraint.
     /// * `cfg` - The new Gas configuration to write in full.
-    pub fn set_gas_config(ctx: Context<SetConfig>, cfg: GasConfig) -> Result<()> {
-        set_gas_config_handler(ctx, cfg)
+    pub fn set_gas_config(ctx: Context<SetConfig>, gas_config: GasConfig) -> Result<()> {
+        set_gas_config_handler(ctx, gas_config)
     }
 
     /// Updates the configured guardian.
@@ -67,8 +73,8 @@ pub mod base_relayer {
     /// * `ctx` - The context containing the `cfg` PDA and the `guardian` signer.
     ///           Authorization is enforced via an Anchor `has_one` constraint.
     /// * `cfg` - The new guardian with permissions to update other configs.
-    pub fn set_guardian(ctx: Context<SetConfig>, guardian: Pubkey) -> Result<()> {
-        set_guardian_handler(ctx, guardian)
+    pub fn set_guardian(ctx: Context<SetConfig>, new_guardian: Pubkey) -> Result<()> {
+        set_guardian_handler(ctx, new_guardian)
     }
 
     /// Pays the gas cost for relaying a message to Base and records the request.

--- a/solana/programs/base_relayer/src/state/cfg.rs
+++ b/solana/programs/base_relayer/src/state/cfg.rs
@@ -11,4 +11,6 @@ pub struct Cfg {
     pub eip1559: Eip1559,
     /// Gas configuration
     pub gas_config: GasConfig,
+    /// Canonical nonce
+    pub nonce: u64,
 }

--- a/solana/programs/base_relayer/src/state/message_to_relay.rs
+++ b/solana/programs/base_relayer/src/state/message_to_relay.rs
@@ -3,6 +3,7 @@ use anchor_lang::prelude::*;
 #[account]
 #[derive(Debug, PartialEq, Eq, InitSpace)]
 pub struct MessageToRelay {
+    pub nonce: u64,
     pub outgoing_message: Pubkey,
     pub gas_limit: u64,
 }

--- a/solana/programs/base_relayer/src/test_utils/mod.rs
+++ b/solana/programs/base_relayer/src/test_utils/mod.rs
@@ -13,24 +13,18 @@ use crate::{
     accounts,
     constants::CFG_SEED,
     instruction::Initialize,
-    internal::{Eip1559, Eip1559Config, GasConfig},
-    state::Cfg,
+    internal::{Eip1559Config, GasConfig},
     ID,
 };
 pub const TEST_GAS_FEE_RECEIVER: Pubkey = pubkey!("eEwCrQLBdQchykrkYitkYUZskd7MPrU2YxBXcPDPnMt");
 
-impl Eip1559 {
+impl Eip1559Config {
     pub fn test_new() -> Self {
         Self {
-            config: Eip1559Config {
-                target: 5_000_000,
-                denominator: 2,
-                window_duration_seconds: 1,
-                minimum_base_fee: 1,
-            },
-            current_base_fee: 100,
-            current_window_gas_used: 0,
-            window_start_time: 1747440000,
+            target: 5_000_000,
+            denominator: 2,
+            window_duration_seconds: 1,
+            minimum_base_fee: 1,
         }
     }
 }
@@ -82,11 +76,9 @@ pub fn setup_program_and_svm() -> (
         program_id: ID,
         accounts,
         data: Initialize {
-            cfg: Cfg {
-                guardian: guardian.pubkey(),
-                eip1559: Eip1559::test_new(),
-                gas_config: GasConfig::test_new(TEST_GAS_FEE_RECEIVER),
-            },
+            new_guardian: guardian.pubkey(),
+            eip1559_config: Eip1559Config::test_new(),
+            gas_config: GasConfig::test_new(TEST_GAS_FEE_RECEIVER),
         }
         .data(),
     };

--- a/solana/programs/bridge/src/common/internal/math.rs
+++ b/solana/programs/bridge/src/common/internal/math.rs
@@ -35,7 +35,7 @@ mod tests {
 
     /// Helper function to check if two values are approximately equal within tolerance
     fn approx_eq(a: u128, b: u128, tolerance_percent: f64) -> bool {
-        let diff = if a > b { a - b } else { b - a };
+        let diff = a.abs_diff(b);
         let max_val = if a > b { a } else { b };
         if max_val == 0 {
             return diff == 0;

--- a/solana/programs/bridge/src/solana_to_base/instructions/mod.rs
+++ b/solana/programs/bridge/src/solana_to_base/instructions/mod.rs
@@ -20,14 +20,6 @@ pub use bridge_wrapped_token::*;
 pub mod buffered;
 pub use buffered::*;
 
-#[derive(AnchorSerialize, AnchorDeserialize)]
-pub struct TransferParams {
-    pub to: [u8; 20],
-    pub remote_token: [u8; 20],
-    pub amount: u64,
-    pub call: Option<Call>,
-}
-
 pub fn check_call(call: &Call) -> Result<()> {
     require!(
         matches!(call.ty, CallType::Call | CallType::DelegateCall) || call.to == [0; 20],


### PR DESCRIPTION
While working on the oracle updates, I realized some nonce tracking for the relayer feature would be useful for our offchain tracking of which messages get executed. This PR adds this nonce tracking and includes some other minor refactors.

- The `base_relayer` program on Solana now has a canonical monotonically incrementing nonce that is separate from the nonce that bridge messages are already getting (since not necessarily every message will be using the relayer feature)
- On Base, the `RelayerOrchestrator` contract now tracks a `nextNonce` storage variable that the oracle can use as an anchor for what the next expected nonce to execute should be
- The `RelayerOrchestrator` now expects messages to be executed to be wrapped in its own struct `MessageToExecute` which includes the `IncomingMessage` and the relayer nonce
- Notably, the `RelayerOrchestrator` contract will not revert if a nonce issue is detected - this is intended behavior to avoid blocking message pre-validation due to an issue in the relaying system. If a nonce issue is detected, the contract will just discard the batch of messages to be executed and not invoke the `Bridge` contract
  - If the relaying system misses a message to execute for any reason, the oracle can re-sync the next expected nonce from the `nextNonce` variable and re-build the batch of messages to execute in its next transaction attempt