### PR TITLE
feat: add prove message buffering to Solana program

### DIFF
--- a/solana/programs/bridge/src/base_to_solana/instructions/buffered/append_to_prove_buffer_data.rs
+++ b/solana/programs/bridge/src/base_to_solana/instructions/buffered/append_to_prove_buffer_data.rs
@@ -1,0 +1,32 @@
+use anchor_lang::prelude::*;
+
+use crate::base_to_solana::ProveBuffer;
+
+/// Append chunk of serialized `Message` data to the `ProveBuffer`.
+#[derive(Accounts)]
+pub struct AppendToProveBufferData<'info> {
+    /// Owner authorized to modify the buffer
+    pub owner: Signer<'info>,
+
+    /// Prove buffer account to append data to
+    #[account(
+        mut,
+        has_one = owner @ AppendToProveBufferError::Unauthorized,
+    )]
+    pub prove_buffer: Account<'info, ProveBuffer>,
+}
+
+pub fn append_to_prove_buffer_data_handler(
+    ctx: Context<AppendToProveBufferData>,
+    chunk: Vec<u8>,
+) -> Result<()> {
+    let buf = &mut ctx.accounts.prove_buffer;
+    buf.data.extend_from_slice(&chunk);
+    Ok(())
+}
+
+#[error_code]
+pub enum AppendToProveBufferError {
+    #[msg("Only the owner can modify this prove buffer")]
+    Unauthorized,
+}

--- a/solana/programs/bridge/src/base_to_solana/instructions/buffered/append_to_prove_buffer_data.rs
+++ b/solana/programs/bridge/src/base_to_solana/instructions/buffered/append_to_prove_buffer_data.rs
@@ -30,3 +30,143 @@ pub enum AppendToProveBufferError {
     #[msg("Only the owner can modify this prove buffer")]
     Unauthorized,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::common::BRIDGE_SEED;
+    use anchor_lang::{
+        solana_program::{instruction::Instruction, native_token::LAMPORTS_PER_SOL},
+        system_program, InstructionData,
+    };
+    use solana_keypair::Keypair;
+    use solana_message::Message;
+    use solana_signer::Signer;
+    use solana_transaction::Transaction;
+
+    use crate::{
+        accounts,
+        instruction::{
+            AppendToProveBufferData as AppendToProveBufferDataIx, InitializeProveBuffer,
+        },
+        test_utils::setup_bridge_and_svm,
+        ID,
+    };
+
+    fn setup_prove_buffer(
+        svm: &mut litesvm::LiteSVM,
+        owner: &solana_keypair::Keypair,
+        prove_buffer: &solana_keypair::Keypair,
+        max_data_len: u64,
+        max_proof_len: u64,
+    ) {
+        let bridge_pda = Pubkey::find_program_address(&[BRIDGE_SEED], &ID).0;
+
+        let init_accounts = accounts::InitializeProveBuffer {
+            payer: owner.pubkey(),
+            bridge: bridge_pda,
+            prove_buffer: prove_buffer.pubkey(),
+            system_program: system_program::ID,
+        }
+        .to_account_metas(None);
+
+        let init_ix = Instruction {
+            program_id: ID,
+            accounts: init_accounts,
+            data: InitializeProveBuffer {
+                max_data_len,
+                max_proof_len,
+            }
+            .data(),
+        };
+
+        let init_tx = Transaction::new(
+            &[owner, prove_buffer],
+            Message::new(&[init_ix], Some(&owner.pubkey())),
+            svm.latest_blockhash(),
+        );
+
+        svm.send_transaction(init_tx)
+            .expect("Failed to initialize prove buffer");
+    }
+
+    #[test]
+    fn test_append_to_prove_buffer_data_success() {
+        let (mut svm, _payer, _bridge_pda) = setup_bridge_and_svm();
+
+        let owner = Keypair::new();
+        svm.airdrop(&owner.pubkey(), LAMPORTS_PER_SOL).unwrap();
+
+        let prove_buffer = Keypair::new();
+        setup_prove_buffer(&mut svm, &owner, &prove_buffer, 1024, 8);
+
+        let chunk = vec![0x01, 0x02, 0x03];
+
+        let accounts = accounts::AppendToProveBufferData {
+            owner: owner.pubkey(),
+            prove_buffer: prove_buffer.pubkey(),
+        }
+        .to_account_metas(None);
+
+        let ix = Instruction {
+            program_id: ID,
+            accounts,
+            data: AppendToProveBufferDataIx {
+                chunk: chunk.clone(),
+            }
+            .data(),
+        };
+
+        let tx = Transaction::new(
+            &[&owner],
+            Message::new(&[ix], Some(&owner.pubkey())),
+            svm.latest_blockhash(),
+        );
+
+        svm.send_transaction(tx)
+            .expect("Failed to append to prove buffer data");
+
+        let acct = svm.get_account(&prove_buffer.pubkey()).unwrap();
+        let buf = ProveBuffer::try_deserialize(&mut &acct.data[..]).unwrap();
+        assert_eq!(buf.data, chunk);
+    }
+
+    #[test]
+    fn test_append_to_prove_buffer_data_unauthorized() {
+        let (mut svm, _payer, _bridge_pda) = setup_bridge_and_svm();
+
+        let owner = Keypair::new();
+        svm.airdrop(&owner.pubkey(), LAMPORTS_PER_SOL).unwrap();
+
+        let unauthorized = Keypair::new();
+        svm.airdrop(&unauthorized.pubkey(), LAMPORTS_PER_SOL)
+            .unwrap();
+
+        let prove_buffer = Keypair::new();
+        setup_prove_buffer(&mut svm, &owner, &prove_buffer, 256, 4);
+
+        let accounts = accounts::AppendToProveBufferData {
+            owner: unauthorized.pubkey(),
+            prove_buffer: prove_buffer.pubkey(),
+        }
+        .to_account_metas(None);
+
+        let ix = Instruction {
+            program_id: ID,
+            accounts,
+            data: AppendToProveBufferDataIx { chunk: vec![0xAA] }.data(),
+        };
+
+        let tx = Transaction::new(
+            &[&unauthorized],
+            Message::new(&[ix], Some(&unauthorized.pubkey())),
+            svm.latest_blockhash(),
+        );
+
+        let result = svm.send_transaction(tx);
+        assert!(result.is_err(), "Expected unauthorized append to fail");
+        let err = format!("{:?}", result.unwrap_err());
+        assert!(err.contains("Unauthorized"), "Unexpected error: {}", err);
+    }
+}

--- a/solana/programs/bridge/src/base_to_solana/instructions/buffered/append_to_prove_buffer_proof.rs
+++ b/solana/programs/bridge/src/base_to_solana/instructions/buffered/append_to_prove_buffer_proof.rs
@@ -1,0 +1,32 @@
+use anchor_lang::prelude::*;
+
+use crate::base_to_solana::ProveBuffer;
+
+/// Append chunk of MMR proof nodes to the `ProveBuffer`.
+#[derive(Accounts)]
+pub struct AppendToProveBufferProof<'info> {
+    /// Owner authorized to modify the buffer
+    pub owner: Signer<'info>,
+
+    /// Prove buffer account to append proof nodes to
+    #[account(
+        mut,
+        has_one = owner @ AppendToProveBufferProofError::Unauthorized,
+    )]
+    pub prove_buffer: Account<'info, ProveBuffer>,
+}
+
+pub fn append_to_prove_buffer_proof_handler(
+    ctx: Context<AppendToProveBufferProof>,
+    proof_chunk: Vec<[u8; 32]>,
+) -> Result<()> {
+    let buf = &mut ctx.accounts.prove_buffer;
+    buf.proof.extend_from_slice(&proof_chunk);
+    Ok(())
+}
+
+#[error_code]
+pub enum AppendToProveBufferProofError {
+    #[msg("Only the owner can modify this prove buffer")]
+    Unauthorized,
+}

--- a/solana/programs/bridge/src/base_to_solana/instructions/buffered/append_to_prove_buffer_proof.rs
+++ b/solana/programs/bridge/src/base_to_solana/instructions/buffered/append_to_prove_buffer_proof.rs
@@ -30,3 +30,146 @@ pub enum AppendToProveBufferProofError {
     #[msg("Only the owner can modify this prove buffer")]
     Unauthorized,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::common::BRIDGE_SEED;
+    use anchor_lang::{
+        solana_program::{instruction::Instruction, native_token::LAMPORTS_PER_SOL},
+        system_program, InstructionData,
+    };
+    use solana_keypair::Keypair;
+    use solana_message::Message;
+    use solana_signer::Signer;
+    use solana_transaction::Transaction;
+
+    use crate::{
+        accounts,
+        instruction::{
+            AppendToProveBufferProof as AppendToProveBufferProofIx, InitializeProveBuffer,
+        },
+        test_utils::setup_bridge_and_svm,
+        ID,
+    };
+
+    fn setup_prove_buffer(
+        svm: &mut litesvm::LiteSVM,
+        owner: &solana_keypair::Keypair,
+        prove_buffer: &solana_keypair::Keypair,
+        max_data_len: u64,
+        max_proof_len: u64,
+    ) {
+        let bridge_pda = Pubkey::find_program_address(&[BRIDGE_SEED], &ID).0;
+
+        let init_accounts = accounts::InitializeProveBuffer {
+            payer: owner.pubkey(),
+            bridge: bridge_pda,
+            prove_buffer: prove_buffer.pubkey(),
+            system_program: system_program::ID,
+        }
+        .to_account_metas(None);
+
+        let init_ix = Instruction {
+            program_id: ID,
+            accounts: init_accounts,
+            data: InitializeProveBuffer {
+                max_data_len,
+                max_proof_len,
+            }
+            .data(),
+        };
+
+        let init_tx = Transaction::new(
+            &[owner, prove_buffer],
+            Message::new(&[init_ix], Some(&owner.pubkey())),
+            svm.latest_blockhash(),
+        );
+
+        svm.send_transaction(init_tx)
+            .expect("Failed to initialize prove buffer");
+    }
+
+    #[test]
+    fn test_append_to_prove_buffer_proof_success() {
+        let (mut svm, _payer, _bridge_pda) = setup_bridge_and_svm();
+
+        let owner = Keypair::new();
+        svm.airdrop(&owner.pubkey(), LAMPORTS_PER_SOL).unwrap();
+
+        let prove_buffer = Keypair::new();
+        setup_prove_buffer(&mut svm, &owner, &prove_buffer, 1024, 8);
+
+        let chunk = vec![[1u8; 32], [2u8; 32]];
+
+        let accounts = accounts::AppendToProveBufferProof {
+            owner: owner.pubkey(),
+            prove_buffer: prove_buffer.pubkey(),
+        }
+        .to_account_metas(None);
+
+        let ix = Instruction {
+            program_id: ID,
+            accounts,
+            data: AppendToProveBufferProofIx {
+                proof_chunk: chunk.clone(),
+            }
+            .data(),
+        };
+
+        let tx = Transaction::new(
+            &[&owner],
+            Message::new(&[ix], Some(&owner.pubkey())),
+            svm.latest_blockhash(),
+        );
+
+        svm.send_transaction(tx)
+            .expect("Failed to append to prove buffer proof");
+
+        let acct = svm.get_account(&prove_buffer.pubkey()).unwrap();
+        let buf = ProveBuffer::try_deserialize(&mut &acct.data[..]).unwrap();
+        assert_eq!(buf.proof, chunk);
+    }
+
+    #[test]
+    fn test_append_to_prove_buffer_proof_unauthorized() {
+        let (mut svm, _payer, _bridge_pda) = setup_bridge_and_svm();
+
+        let owner = Keypair::new();
+        svm.airdrop(&owner.pubkey(), LAMPORTS_PER_SOL).unwrap();
+
+        let unauthorized = Keypair::new();
+        svm.airdrop(&unauthorized.pubkey(), LAMPORTS_PER_SOL)
+            .unwrap();
+
+        let prove_buffer = Keypair::new();
+        setup_prove_buffer(&mut svm, &owner, &prove_buffer, 256, 4);
+
+        let accounts = accounts::AppendToProveBufferProof {
+            owner: unauthorized.pubkey(),
+            prove_buffer: prove_buffer.pubkey(),
+        }
+        .to_account_metas(None);
+
+        let ix = Instruction {
+            program_id: ID,
+            accounts,
+            data: AppendToProveBufferProofIx {
+                proof_chunk: vec![[0xAAu8; 32]],
+            }
+            .data(),
+        };
+
+        let tx = Transaction::new(
+            &[&unauthorized],
+            Message::new(&[ix], Some(&unauthorized.pubkey())),
+            svm.latest_blockhash(),
+        );
+
+        let result = svm.send_transaction(tx);
+        assert!(result.is_err(), "Expected unauthorized append to fail");
+        let err = format!("{:?}", result.unwrap_err());
+        assert!(err.contains("Unauthorized"), "Unexpected error: {}", err);
+    }
+}

--- a/solana/programs/bridge/src/base_to_solana/instructions/buffered/initialize_prove_buffer.rs
+++ b/solana/programs/bridge/src/base_to_solana/instructions/buffered/initialize_prove_buffer.rs
@@ -1,0 +1,46 @@
+use anchor_lang::prelude::*;
+
+use crate::{
+    base_to_solana::ProveBuffer,
+    common::{bridge::Bridge, BRIDGE_SEED, DISCRIMINATOR_LEN},
+};
+
+/// Accounts for initializing a `ProveBuffer` which can hold large prove inputs.
+#[derive(Accounts)]
+#[instruction(_max_data_len: u64, _max_proof_len: u64)]
+pub struct InitializeProveBuffer<'info> {
+    /// Payer funds the buffer account creation
+    #[account(mut)]
+    pub payer: Signer<'info>,
+
+    /// Bridge for pause checks (future use); also a consistent pattern like call buffers
+    #[account(
+        seeds = [BRIDGE_SEED],
+        bump
+    )]
+    pub bridge: Account<'info, Bridge>,
+
+    /// Prove buffer to be created with capacity sized by the provided max lengths
+    #[account(
+        init,
+        payer = payer,
+        space = DISCRIMINATOR_LEN + ProveBuffer::space(_max_data_len as usize, _max_proof_len as usize),
+    )]
+    pub prove_buffer: Account<'info, ProveBuffer>,
+
+    pub system_program: Program<'info, System>,
+}
+
+pub fn initialize_prove_buffer_handler(
+    ctx: Context<InitializeProveBuffer>,
+    _max_data_len: u64,
+    _max_proof_len: u64,
+) -> Result<()> {
+    *ctx.accounts.prove_buffer = ProveBuffer {
+        owner: ctx.accounts.payer.key(),
+        data: Vec::new(),
+        proof: Vec::new(),
+    };
+
+    Ok(())
+}

--- a/solana/programs/bridge/src/base_to_solana/instructions/buffered/initialize_prove_buffer.rs
+++ b/solana/programs/bridge/src/base_to_solana/instructions/buffered/initialize_prove_buffer.rs
@@ -44,3 +44,128 @@ pub fn initialize_prove_buffer_handler(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use anchor_lang::{
+        solana_program::{instruction::Instruction, native_token::LAMPORTS_PER_SOL},
+        system_program, InstructionData,
+    };
+    use solana_keypair::Keypair;
+    use solana_message::Message;
+    use solana_signer::Signer as _;
+    use solana_transaction::Transaction;
+
+    use crate::{
+        accounts, instruction::InitializeProveBuffer as InitializeProveBufferIx,
+        test_utils::setup_bridge_and_svm, ID,
+    };
+
+    #[test]
+    fn test_initialize_prove_buffer_success() {
+        let (mut svm, _payer_setup, bridge_pda) = setup_bridge_and_svm();
+
+        // Create payer and fund
+        let payer = Keypair::new();
+        svm.airdrop(&payer.pubkey(), LAMPORTS_PER_SOL).unwrap();
+
+        // Prove buffer account
+        let prove_buffer = Keypair::new();
+
+        // Parameters
+        let max_data_len: u64 = 1024;
+        let max_proof_len: u64 = 8;
+
+        // Accounts metas
+        let accounts = accounts::InitializeProveBuffer {
+            payer: payer.pubkey(),
+            bridge: bridge_pda,
+            prove_buffer: prove_buffer.pubkey(),
+            system_program: system_program::ID,
+        }
+        .to_account_metas(None);
+
+        // Instruction
+        let ix = Instruction {
+            program_id: ID,
+            accounts,
+            data: InitializeProveBufferIx {
+                max_data_len,
+                max_proof_len,
+            }
+            .data(),
+        };
+
+        // Transaction
+        let tx = Transaction::new(
+            &[&payer, &prove_buffer],
+            Message::new(&[ix], Some(&payer.pubkey())),
+            svm.latest_blockhash(),
+        );
+
+        svm.send_transaction(tx)
+            .expect("initialize_prove_buffer should succeed");
+
+        // Verify account owner and state
+        let acct = svm.get_account(&prove_buffer.pubkey()).unwrap();
+        assert_eq!(acct.owner, ID);
+
+        let buf = ProveBuffer::try_deserialize(&mut &acct.data[..]).unwrap();
+        assert_eq!(buf.owner, payer.pubkey());
+        assert!(buf.data.is_empty());
+        assert!(buf.proof.is_empty());
+    }
+
+    #[test]
+    fn test_initialize_prove_buffer_allocates_expected_space() {
+        let (mut svm, _payer_setup, bridge_pda) = setup_bridge_and_svm();
+
+        // Create payer and fund
+        let payer = Keypair::new();
+        svm.airdrop(&payer.pubkey(), LAMPORTS_PER_SOL).unwrap();
+
+        // Prove buffer account
+        let prove_buffer = Keypair::new();
+
+        // Parameters
+        let max_data_len: u64 = 512;
+        let max_proof_len: u64 = 4;
+
+        // Accounts metas
+        let accounts = accounts::InitializeProveBuffer {
+            payer: payer.pubkey(),
+            bridge: bridge_pda,
+            prove_buffer: prove_buffer.pubkey(),
+            system_program: system_program::ID,
+        }
+        .to_account_metas(None);
+
+        // Instruction
+        let ix = Instruction {
+            program_id: ID,
+            accounts,
+            data: InitializeProveBufferIx {
+                max_data_len,
+                max_proof_len,
+            }
+            .data(),
+        };
+
+        // Transaction
+        let tx = Transaction::new(
+            &[&payer, &prove_buffer],
+            Message::new(&[ix], Some(&payer.pubkey())),
+            svm.latest_blockhash(),
+        );
+
+        svm.send_transaction(tx).unwrap();
+
+        // Verify allocated size matches expectation
+        let acct = svm.get_account(&prove_buffer.pubkey()).unwrap();
+        let expected = crate::common::DISCRIMINATOR_LEN
+            + ProveBuffer::space(max_data_len as usize, max_proof_len as usize);
+        assert_eq!(acct.data.len(), expected);
+    }
+}

--- a/solana/programs/bridge/src/base_to_solana/instructions/buffered/mod.rs
+++ b/solana/programs/bridge/src/base_to_solana/instructions/buffered/mod.rs
@@ -1,0 +1,9 @@
+pub mod append_to_prove_buffer_data;
+pub mod append_to_prove_buffer_proof;
+pub mod initialize_prove_buffer;
+pub mod prove_message_buffered;
+
+pub use append_to_prove_buffer_data::*;
+pub use append_to_prove_buffer_proof::*;
+pub use initialize_prove_buffer::*;
+pub use prove_message_buffered::*;

--- a/solana/programs/bridge/src/base_to_solana/instructions/buffered/prove_message_buffered.rs
+++ b/solana/programs/bridge/src/base_to_solana/instructions/buffered/prove_message_buffered.rs
@@ -1,0 +1,545 @@
+use anchor_lang::{prelude::*, solana_program::keccak};
+
+use crate::{
+    base_to_solana::{
+        constants::INCOMING_MESSAGE_SEED, internal::mmr, state::IncomingMessage, Message,
+        OutputRoot, ProveBuffer,
+    },
+    common::{bridge::Bridge, BRIDGE_SEED, DISCRIMINATOR_LEN},
+};
+
+/// Buffered variant of `prove_message` that reads data/proof from a `ProveBuffer` and closes it.
+#[derive(Accounts)]
+#[instruction(nonce: u64, sender: [u8; 20], message_hash: [u8; 32])]
+pub struct ProveMessageBuffered<'info> {
+    /// Payer funds the IncomingMessage account
+    #[account(mut)]
+    pub payer: Signer<'info>,
+
+    /// Output root to verify the proof against
+    pub output_root: Account<'info, OutputRoot>,
+
+    /// The incoming message account created if proof verifies
+    #[account(
+        init,
+        payer = payer,
+        space = DISCRIMINATOR_LEN + IncomingMessage::space(prove_buffer.data.len()),
+        seeds = [INCOMING_MESSAGE_SEED, &message_hash],
+        bump
+    )]
+    pub message: Account<'info, IncomingMessage>,
+
+    /// Bridge for pause check
+    #[account(seeds = [BRIDGE_SEED], bump)]
+    pub bridge: Account<'info, Bridge>,
+
+    /// Owner receives rent when buffer is closed
+    #[account(mut)]
+    pub owner: Signer<'info>,
+
+    /// Prove buffer containing data and proof; closed on success
+    #[account(
+        mut,
+        close = owner,
+        has_one = owner @ ProveMessageBufferedError::Unauthorized,
+    )]
+    pub prove_buffer: Account<'info, ProveBuffer>,
+
+    pub system_program: Program<'info, System>,
+}
+
+pub fn prove_message_buffered_handler(
+    ctx: Context<ProveMessageBuffered>,
+    nonce: u64,
+    sender: [u8; 20],
+    message_hash: [u8; 32],
+) -> Result<()> {
+    // Pause
+    require!(
+        !ctx.accounts.bridge.paused,
+        ProveMessageBufferedError::BridgePaused
+    );
+
+    // Verify hash
+    let data = &ctx.accounts.prove_buffer.data;
+    let computed_hash = hash_message(&nonce.to_be_bytes(), &sender, data);
+    require!(
+        message_hash == computed_hash,
+        ProveMessageBufferedError::InvalidMessageHash
+    );
+
+    // Verify proof
+    mmr::verify_proof(
+        &ctx.accounts.output_root.root,
+        &message_hash,
+        &nonce,
+        &ctx.accounts.prove_buffer.proof,
+        ctx.accounts.output_root.total_leaf_count,
+    )?;
+
+    // Deserialize and save
+    let message_enum = Message::try_from_slice(data)?;
+    *ctx.accounts.message = IncomingMessage {
+        executed: false,
+        sender,
+        message: message_enum,
+    };
+
+    Ok(())
+}
+
+fn hash_message(nonce: &[u8], sender: &[u8; 20], data: &[u8]) -> [u8; 32] {
+    let mut data_to_hash = Vec::new();
+    data_to_hash.extend_from_slice(nonce);
+    data_to_hash.extend_from_slice(sender);
+    data_to_hash.extend_from_slice(data);
+    keccak::hash(&data_to_hash).0
+}
+
+#[error_code]
+pub enum ProveMessageBufferedError {
+    #[msg("Invalid message hash")]
+    InvalidMessageHash,
+    #[msg("Only the owner can close this prove buffer")]
+    Unauthorized,
+    #[msg("Bridge is currently paused")]
+    BridgePaused,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use anchor_lang::prelude::Pubkey;
+    use anchor_lang::solana_program::keccak::hash as keccak_hash;
+    use anchor_lang::{solana_program::instruction::Instruction, system_program, InstructionData};
+    use litesvm::LiteSVM;
+    use solana_account::Account as SvmAccount;
+    use solana_keypair::Keypair;
+    use solana_message::Message as SolMessage;
+    use solana_signer::Signer as _;
+    use solana_transaction::Transaction;
+
+    use crate::{
+        accounts,
+        base_to_solana::{state::IncomingMessage, Message as BridgeMessage},
+        common::bridge::Bridge,
+        instruction::{
+            AppendToProveBufferData, AppendToProveBufferProof, InitializeProveBuffer,
+            ProveMessageBuffered as ProveMessageBufferedIx,
+        },
+        test_utils::setup_bridge_and_svm,
+        ID,
+    };
+
+    fn create_output_root_account(
+        svm: &mut LiteSVM,
+        root_pk: Pubkey,
+        root: [u8; 32],
+        total_leaf_count: u64,
+    ) {
+        let output_root = crate::base_to_solana::state::OutputRoot {
+            root,
+            total_leaf_count,
+        };
+        let mut data = Vec::new();
+        output_root.try_serialize(&mut data).unwrap();
+        svm.set_account(
+            root_pk,
+            SvmAccount {
+                lamports: 1_000_000,
+                data,
+                owner: ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    }
+
+    fn compute_message_hash(nonce: u64, sender: [u8; 20], data: &[u8]) -> [u8; 32] {
+        let mut v = Vec::new();
+        v.extend_from_slice(&nonce.to_be_bytes());
+        v.extend_from_slice(&sender);
+        v.extend_from_slice(data);
+        keccak_hash(&v).0
+    }
+
+    fn buffered_message_setup(
+        svm: &mut LiteSVM,
+        bridge_pda: Pubkey,
+    ) -> ([u8; 32], Pubkey, Keypair, Keypair, u64, [u8; 20], Vec<u8>) {
+        // Owner of the prove buffer
+        let owner = Keypair::new();
+        svm.airdrop(&owner.pubkey(), 1_000_000_000).unwrap();
+
+        // Create prove buffer account via initialize
+        let prove_buffer = Keypair::new();
+        let init_accounts = accounts::InitializeProveBuffer {
+            payer: owner.pubkey(),
+            bridge: bridge_pda,
+            prove_buffer: prove_buffer.pubkey(),
+            system_program: system_program::ID,
+        }
+        .to_account_metas(None);
+
+        let init_ix = Instruction {
+            program_id: ID,
+            accounts: init_accounts,
+            data: InitializeProveBuffer {
+                max_data_len: 1024,
+                max_proof_len: 8,
+            }
+            .data(),
+        };
+
+        let init_tx = Transaction::new(
+            &[&owner, &prove_buffer],
+            SolMessage::new(&[init_ix], Some(&owner.pubkey())),
+            svm.latest_blockhash(),
+        );
+        svm.send_transaction(init_tx)
+            .expect("initialize_prove_buffer should succeed");
+
+        // Build message data and append to buffer
+        let message = BridgeMessage::Call(vec![]);
+        let message_bytes = message.try_to_vec().unwrap();
+
+        let append_data_accounts = accounts::AppendToProveBufferData {
+            owner: owner.pubkey(),
+            prove_buffer: prove_buffer.pubkey(),
+        }
+        .to_account_metas(None);
+
+        let append_data_ix = Instruction {
+            program_id: ID,
+            accounts: append_data_accounts,
+            data: AppendToProveBufferData {
+                chunk: message_bytes.clone(),
+            }
+            .data(),
+        };
+        let append_data_tx = Transaction::new(
+            &[&owner],
+            SolMessage::new(&[append_data_ix], Some(&owner.pubkey())),
+            svm.latest_blockhash(),
+        );
+        svm.send_transaction(append_data_tx)
+            .expect("append data should succeed");
+
+        // Append empty proof (MMR with one leaf)
+        let append_proof_accounts = accounts::AppendToProveBufferProof {
+            owner: owner.pubkey(),
+            prove_buffer: prove_buffer.pubkey(),
+        }
+        .to_account_metas(None);
+        let append_proof_ix = Instruction {
+            program_id: ID,
+            accounts: append_proof_accounts,
+            data: AppendToProveBufferProof {
+                proof_chunk: vec![],
+            }
+            .data(),
+        };
+        let append_proof_tx = Transaction::new(
+            &[&owner],
+            SolMessage::new(&[append_proof_ix], Some(&owner.pubkey())),
+            svm.latest_blockhash(),
+        );
+        svm.send_transaction(append_proof_tx)
+            .expect("append proof should succeed");
+
+        // Create OutputRoot account with root = message_hash for total_leaf_count = 1
+        let nonce = 0u64;
+        let sender = [7u8; 20];
+        let message_hash = compute_message_hash(nonce, sender, &message_bytes);
+        let output_root_pk = Keypair::new().pubkey();
+        create_output_root_account(svm, output_root_pk, message_hash, 1);
+
+        (
+            message_hash,
+            output_root_pk,
+            owner,
+            prove_buffer,
+            nonce,
+            sender,
+            message_bytes,
+        )
+    }
+
+    #[test]
+    fn test_prove_message_buffered_success_creates_incoming_message_and_closes_buffer() {
+        let (mut svm, payer, bridge_pda) = setup_bridge_and_svm();
+
+        let (message_hash, output_root_pk, owner, prove_buffer, nonce, sender, message_bytes) =
+            buffered_message_setup(&mut svm, bridge_pda);
+
+        // Incoming message PDA derived from seed and message_hash
+        let incoming_pda = Pubkey::find_program_address(
+            &[
+                crate::base_to_solana::constants::INCOMING_MESSAGE_SEED,
+                &message_hash,
+            ],
+            &ID,
+        )
+        .0;
+
+        // Prove using buffered data
+        let prove_accounts = accounts::ProveMessageBuffered {
+            payer: payer.pubkey(),
+            output_root: output_root_pk,
+            message: incoming_pda,
+            bridge: bridge_pda,
+            owner: owner.pubkey(),
+            prove_buffer: prove_buffer.pubkey(),
+            system_program: system_program::ID,
+        }
+        .to_account_metas(None);
+
+        let prove_ix = Instruction {
+            program_id: ID,
+            accounts: prove_accounts,
+            data: ProveMessageBufferedIx {
+                nonce,
+                sender,
+                message_hash,
+            }
+            .data(),
+        };
+
+        let prove_tx = Transaction::new(
+            &[&payer, &owner],
+            SolMessage::new(&[prove_ix], Some(&payer.pubkey())),
+            svm.latest_blockhash(),
+        );
+        svm.send_transaction(prove_tx)
+            .expect("prove_message_buffered should succeed");
+
+        // Verify IncomingMessage account contents
+        let msg_account = svm.get_account(&incoming_pda).unwrap();
+        assert_eq!(msg_account.owner, ID);
+        let incoming = IncomingMessage::try_deserialize(&mut &msg_account.data[..]).unwrap();
+        assert!(!incoming.executed);
+        assert_eq!(incoming.sender, sender);
+        let stored_bytes = incoming.message.clone().try_to_vec().unwrap();
+        assert_eq!(stored_bytes, message_bytes);
+
+        // Verify the prove buffer was closed
+        let buffer_account = svm.get_account(&prove_buffer.pubkey()).unwrap();
+        assert_eq!(buffer_account.lamports, 0);
+        assert_eq!(buffer_account.data.len(), 0);
+        assert_eq!(buffer_account.owner, system_program::ID);
+    }
+
+    #[test]
+    fn test_prove_message_buffered_fails_with_unauthorized_owner() {
+        let (mut svm, payer, bridge_pda) = setup_bridge_and_svm();
+
+        let (message_hash, output_root_pk, _, prove_buffer, nonce, sender, _) =
+            buffered_message_setup(&mut svm, bridge_pda);
+
+        let incoming_pda = Pubkey::find_program_address(
+            &[
+                crate::base_to_solana::constants::INCOMING_MESSAGE_SEED,
+                &message_hash,
+            ],
+            &ID,
+        )
+        .0;
+
+        let unauthorized = Keypair::new();
+        svm.airdrop(&unauthorized.pubkey(), 1_000_000_000).unwrap();
+
+        // Attempt prove with wrong owner
+        let prove_accounts = accounts::ProveMessageBuffered {
+            payer: payer.pubkey(),
+            output_root: output_root_pk,
+            message: incoming_pda,
+            bridge: bridge_pda,
+            owner: unauthorized.pubkey(), // wrong owner
+            prove_buffer: prove_buffer.pubkey(),
+            system_program: system_program::ID,
+        }
+        .to_account_metas(None);
+
+        let prove_ix = Instruction {
+            program_id: ID,
+            accounts: prove_accounts,
+            data: ProveMessageBufferedIx {
+                nonce,
+                sender,
+                message_hash,
+            }
+            .data(),
+        };
+
+        let tx = Transaction::new(
+            &[&payer, &unauthorized],
+            SolMessage::new(&[prove_ix], Some(&payer.pubkey())),
+            svm.latest_blockhash(),
+        );
+        let result = svm.send_transaction(tx);
+        assert!(result.is_err(), "expected unauthorized error");
+        let err = format!("{:?}", result.unwrap_err());
+        assert!(err.contains("Unauthorized"), "unexpected error: {}", err);
+    }
+
+    #[test]
+    fn test_prove_message_buffered_fails_with_invalid_message_hash() {
+        let (mut svm, payer, bridge_pda) = setup_bridge_and_svm();
+
+        let owner = Keypair::new();
+        svm.airdrop(&owner.pubkey(), 1_000_000_000).unwrap();
+
+        let prove_buffer = Keypair::new();
+        let init_accounts = accounts::InitializeProveBuffer {
+            payer: owner.pubkey(),
+            bridge: bridge_pda,
+            prove_buffer: prove_buffer.pubkey(),
+            system_program: system_program::ID,
+        }
+        .to_account_metas(None);
+        let init_ix = Instruction {
+            program_id: ID,
+            accounts: init_accounts,
+            data: InitializeProveBuffer {
+                max_data_len: 16,
+                max_proof_len: 0,
+            }
+            .data(),
+        };
+        let init_tx = Transaction::new(
+            &[&owner, &prove_buffer],
+            SolMessage::new(&[init_ix], Some(&owner.pubkey())),
+            svm.latest_blockhash(),
+        );
+        svm.send_transaction(init_tx).unwrap();
+
+        // Put some data into buffer
+        let message = BridgeMessage::Call(vec![]);
+        let message_bytes = message.try_to_vec().unwrap();
+        let append_accounts = accounts::AppendToProveBufferData {
+            owner: owner.pubkey(),
+            prove_buffer: prove_buffer.pubkey(),
+        }
+        .to_account_metas(None);
+        let append_ix = Instruction {
+            program_id: ID,
+            accounts: append_accounts,
+            data: AppendToProveBufferData {
+                chunk: message_bytes,
+            }
+            .data(),
+        };
+        let append_tx = Transaction::new(
+            &[&owner],
+            SolMessage::new(&[append_ix], Some(&owner.pubkey())),
+            svm.latest_blockhash(),
+        );
+        svm.send_transaction(append_tx).unwrap();
+
+        // Create OutputRoot (values won't matter; hash check fails first)
+        let output_root_pk = Keypair::new().pubkey();
+        create_output_root_account(&mut svm, output_root_pk, [9u8; 32], 1);
+
+        let bad_message_hash = [0u8; 32];
+        let incoming_pda = Pubkey::find_program_address(
+            &[
+                crate::base_to_solana::constants::INCOMING_MESSAGE_SEED,
+                &bad_message_hash,
+            ],
+            &ID,
+        )
+        .0;
+
+        let prove_accounts = accounts::ProveMessageBuffered {
+            payer: payer.pubkey(),
+            output_root: output_root_pk,
+            message: incoming_pda,
+            bridge: bridge_pda,
+            owner: owner.pubkey(),
+            prove_buffer: prove_buffer.pubkey(),
+            system_program: system_program::ID,
+        }
+        .to_account_metas(None);
+
+        let prove_ix = Instruction {
+            program_id: ID,
+            accounts: prove_accounts,
+            data: ProveMessageBufferedIx {
+                nonce: 0,
+                sender: [1u8; 20],
+                message_hash: bad_message_hash,
+            }
+            .data(),
+        };
+
+        let tx = Transaction::new(
+            &[&payer, &owner],
+            SolMessage::new(&[prove_ix], Some(&payer.pubkey())),
+            svm.latest_blockhash(),
+        );
+        let result = svm.send_transaction(tx);
+        assert!(result.is_err(), "expected InvalidMessageHash error");
+        let err = format!("{:?}", result.unwrap_err());
+        assert!(err.contains("InvalidMessageHash"));
+    }
+
+    #[test]
+    fn test_prove_message_buffered_fails_when_bridge_paused() {
+        let (mut svm, payer, bridge_pda) = setup_bridge_and_svm();
+
+        let (_, output_root_pk, owner, prove_buffer, _, _, _) =
+            buffered_message_setup(&mut svm, bridge_pda);
+
+        // Pause the bridge
+        let mut bridge_acc = svm.get_account(&bridge_pda).unwrap();
+        let mut bridge = Bridge::try_deserialize(&mut &bridge_acc.data[..]).unwrap();
+        bridge.paused = true;
+        let mut new_data = Vec::new();
+        bridge.try_serialize(&mut new_data).unwrap();
+        bridge_acc.data = new_data;
+        svm.set_account(bridge_pda, bridge_acc).unwrap();
+
+        let incoming_pda = Pubkey::find_program_address(
+            &[
+                crate::base_to_solana::constants::INCOMING_MESSAGE_SEED,
+                &[0u8; 32],
+            ],
+            &ID,
+        )
+        .0;
+
+        let prove_accounts = accounts::ProveMessageBuffered {
+            payer: payer.pubkey(),
+            output_root: output_root_pk,
+            message: incoming_pda,
+            bridge: bridge_pda,
+            owner: owner.pubkey(),
+            prove_buffer: prove_buffer.pubkey(),
+            system_program: system_program::ID,
+        }
+        .to_account_metas(None);
+
+        let prove_ix = Instruction {
+            program_id: ID,
+            accounts: prove_accounts,
+            data: ProveMessageBufferedIx {
+                nonce: 0,
+                sender: [0u8; 20],
+                message_hash: [0u8; 32],
+            }
+            .data(),
+        };
+
+        let tx = Transaction::new(
+            &[&payer, &owner],
+            SolMessage::new(&[prove_ix], Some(&payer.pubkey())),
+            svm.latest_blockhash(),
+        );
+        let result = svm.send_transaction(tx);
+        assert!(result.is_err(), "expected failure when bridge is paused");
+        let err = format!("{:?}", result.unwrap_err());
+        assert!(err.contains("BridgePaused"), "unexpected error: {}", err);
+    }
+}

--- a/solana/programs/bridge/src/base_to_solana/instructions/mod.rs
+++ b/solana/programs/bridge/src/base_to_solana/instructions/mod.rs
@@ -1,8 +1,10 @@
+pub mod buffered;
 pub mod prove_message;
 pub mod register_output_root;
 pub mod relay_message;
 pub mod token;
 
+pub use buffered::*;
 pub use prove_message::*;
 pub use register_output_root::*;
 pub use relay_message::*;

--- a/solana/programs/bridge/src/base_to_solana/state/mod.rs
+++ b/solana/programs/bridge/src/base_to_solana/state/mod.rs
@@ -1,7 +1,9 @@
 pub mod incoming_message;
 pub mod output_root;
+pub mod prove_buffer;
 pub mod signers;
 
 pub use incoming_message::*;
 pub use output_root::*;
+pub use prove_buffer::*;
 pub use signers::*;

--- a/solana/programs/bridge/src/base_to_solana/state/prove_buffer.rs
+++ b/solana/programs/bridge/src/base_to_solana/state/prove_buffer.rs
@@ -1,0 +1,25 @@
+use anchor_lang::prelude::*;
+
+/// A buffer account to stage large Base → Solana prove inputs over multiple transactions.
+/// Stores the serialized `Message` bytes (`data`) and the MMR `proof` nodes.
+#[account]
+#[derive(Debug)]
+pub struct ProveBuffer {
+    /// The owner who can modify and eventually consume this buffer
+    pub owner: Pubkey,
+
+    /// Serialized `Message` data (Anchor-serialized)
+    pub data: Vec<u8>,
+
+    /// MMR proof nodes used to validate inclusion against an OutputRoot
+    pub proof: Vec<[u8; 32]>,
+}
+
+impl ProveBuffer {
+    /// Calculate serialized space needed for a `ProveBuffer` (not including the 8-byte discriminator)
+    pub fn space(max_data_len: usize, max_proof_len: usize) -> usize {
+        32 + // owner
+        4 + max_data_len + // data vec
+        4 + (max_proof_len * 32) // proof vec
+    }
+}

--- a/solana/programs/bridge/src/lib.rs
+++ b/solana/programs/bridge/src/lib.rs
@@ -95,6 +95,67 @@ pub mod bridge {
         prove_message_handler(ctx, nonce, sender, data, proof, message_hash)
     }
 
+    /// Initializes a prove buffer account that can store large prove inputs.
+    /// This account can be used to build up serialized message data and MMR proof nodes
+    /// over multiple transactions before calling `prove_message_buffered`.
+    ///
+    /// # Arguments
+    /// * `ctx`           - The context containing accounts for initialization (payer, bridge, buffer)
+    /// * `max_data_len`  - Maximum total length of serialized `Message` data that will be stored
+    /// * `max_proof_len` - Maximum number of 32-byte MMR proof nodes that will be stored
+    pub fn initialize_prove_buffer(
+        ctx: Context<InitializeProveBuffer>,
+        max_data_len: u64,
+        max_proof_len: u64,
+    ) -> Result<()> {
+        initialize_prove_buffer_handler(ctx, max_data_len, max_proof_len)
+    }
+
+    /// Appends serialized `Message` bytes to an existing prove buffer.
+    /// Only the owner of the prove buffer can append data to it.
+    ///
+    /// # Arguments
+    /// * `ctx`   - The context containing the prove buffer account (owned by signer)
+    /// * `chunk` - Additional serialized `Message` bytes to append to the buffer
+    pub fn append_to_prove_buffer_data(
+        ctx: Context<AppendToProveBufferData>,
+        chunk: Vec<u8>,
+    ) -> Result<()> {
+        append_to_prove_buffer_data_handler(ctx, chunk)
+    }
+
+    /// Appends MMR proof nodes to an existing prove buffer.
+    /// Only the owner of the prove buffer can append proof nodes to it.
+    ///
+    /// # Arguments
+    /// * `ctx`         - The context containing the prove buffer account (owned by signer)
+    /// * `proof_chunk` - Additional MMR proof nodes to append to the buffer
+    pub fn append_to_prove_buffer_proof(
+        ctx: Context<AppendToProveBufferProof>,
+        proof_chunk: Vec<[u8; 32]>,
+    ) -> Result<()> {
+        append_to_prove_buffer_proof_handler(ctx, proof_chunk)
+    }
+
+    /// Proves that a cross-chain message exists using buffered data and proof.
+    /// This function reads the serialized message and MMR proof from a `ProveBuffer`,
+    /// verifies inclusion against a previously registered output root, and stores the
+    /// proven message for later relay execution. The prove buffer is closed on success.
+    ///
+    /// # Arguments
+    /// * `ctx`          - The context containing accounts for verification and message creation
+    /// * `nonce`        - Unique identifier for the cross-chain message
+    /// * `sender`       - The 20-byte Ethereum address that sent the message on Base
+    /// * `message_hash` - The 32-byte hash of the message for verification
+    pub fn prove_message_buffered(
+        ctx: Context<ProveMessageBuffered>,
+        nonce: u64,
+        sender: [u8; 20],
+        message_hash: [u8; 32],
+    ) -> Result<()> {
+        prove_message_buffered_handler(ctx, nonce, sender, message_hash)
+    }
+
     /// Executes a previously proven cross-chain message on Solana.
     /// This function takes a message that has been proven via `prove_message` and executes
     /// its payload using a bridge CPI authority derived from the message sender.


### PR DESCRIPTION
Introduces a buffered proving flow for Base → Solana messages that supports large inputs split across multiple transactions. Some prove inputs (serialized message + MMR proof) can exceed single-transaction limits. Buffering enables chunked uploads and a final atomic prove.

Will open a separate PR tomorrow with additional Base-side validation to prevent creating messages that may still be un-executable even with this buffering solution.