### PR TITLE
chore(CHAIN-2109): update event name

### DIFF
--- a/base/src/libraries/MessageStorageLib.sol
+++ b/base/src/libraries/MessageStorageLib.sol
@@ -44,7 +44,7 @@ library MessageStorageLib {
     /// @param messageHash The message's hash.
     /// @param mmrRoot The root of the MMR after the message is registered.
     /// @param message The message.
-    event MessageRegistered(bytes32 indexed messageHash, bytes32 indexed mmrRoot, Message message);
+    event MessageInitiated(bytes32 indexed messageHash, bytes32 indexed mmrRoot, Message message);
 
     //////////////////////////////////////////////////////////////
     ///                       Errors                           ///
@@ -159,7 +159,7 @@ library MessageStorageLib {
             ++$.nextNonce;
         }
 
-        emit MessageRegistered({messageHash: messageHash, mmrRoot: mmrRoot, message: message});
+        emit MessageInitiated({messageHash: messageHash, mmrRoot: mmrRoot, message: message});
     }
 
     //////////////////////////////////////////////////////////////

--- a/base/test/libraries/MessageStorageLib.t.sol
+++ b/base/test/libraries/MessageStorageLib.t.sol
@@ -121,7 +121,7 @@ contract MessageStorageLibTest is Test {
         // Verify event structure
         assertEq(
             logs[0].topics[0],
-            keccak256("MessageRegistered(bytes32,bytes32,(uint64,address,bytes))"),
+            keccak256("MessageInitiated(bytes32,bytes32,(uint64,address,bytes))"),
             "Event signature mismatch"
         );
         assertEq(logs[0].topics[1], expectedMessageHash, "Message hash mismatch");


### PR DESCRIPTION
We currently have two events named `MessageRegistered` that mean different things. One in `BridgeValidator` when pre-validation occurs, and the other is in `MessageStorageLib` for when a Base --> Solana message is initiated. This PR updates the event name in `MessageStorageLib` to be more descriptive