### PR TITLE
chore(clients): regenerate clients and fix scripts

### DIFF
--- a/clients/ts/src/base-relayer/generated/errors/baseRelayer.ts
+++ b/clients/ts/src/base-relayer/generated/errors/baseRelayer.ts
@@ -14,20 +14,36 @@ import {
 } from '@solana/kit';
 import { BASE_RELAYER_PROGRAM_ADDRESS } from '../programs';
 
+/** UnauthorizedInitialization: Only the upgrade authority can initialize the relayer */
+export const BASE_RELAYER_ERROR__UNAUTHORIZED_INITIALIZATION = 0x2ee0; // 12000
+/** IncorrectRelayerProgram: Incorrect relayer program */
+export const BASE_RELAYER_ERROR__INCORRECT_RELAYER_PROGRAM = 0x2ee1; // 12001
+/** UnauthorizedConfigUpdate: Unauthorized to update configuration */
+export const BASE_RELAYER_ERROR__UNAUTHORIZED_CONFIG_UPDATE = 0x2f44; // 12100
 /** GasLimitTooLow: Gas limit too low */
-export const BASE_RELAYER_ERROR__GAS_LIMIT_TOO_LOW = 0x1770; // 6000
+export const BASE_RELAYER_ERROR__GAS_LIMIT_TOO_LOW = 0x2fa8; // 12200
 /** GasLimitExceeded: Gas limit exceeded */
-export const BASE_RELAYER_ERROR__GAS_LIMIT_EXCEEDED = 0x1771; // 6001
+export const BASE_RELAYER_ERROR__GAS_LIMIT_EXCEEDED = 0x2fa9; // 12201
+/** IncorrectGasFeeReceiver: Incorrect gas fee receiver */
+export const BASE_RELAYER_ERROR__INCORRECT_GAS_FEE_RECEIVER = 0x300c; // 12300
 
 export type BaseRelayerError =
   | typeof BASE_RELAYER_ERROR__GAS_LIMIT_EXCEEDED
-  | typeof BASE_RELAYER_ERROR__GAS_LIMIT_TOO_LOW;
+  | typeof BASE_RELAYER_ERROR__GAS_LIMIT_TOO_LOW
+  | typeof BASE_RELAYER_ERROR__INCORRECT_GAS_FEE_RECEIVER
+  | typeof BASE_RELAYER_ERROR__INCORRECT_RELAYER_PROGRAM
+  | typeof BASE_RELAYER_ERROR__UNAUTHORIZED_CONFIG_UPDATE
+  | typeof BASE_RELAYER_ERROR__UNAUTHORIZED_INITIALIZATION;
 
 let baseRelayerErrorMessages: Record<BaseRelayerError, string> | undefined;
 if (process.env.NODE_ENV !== 'production') {
   baseRelayerErrorMessages = {
     [BASE_RELAYER_ERROR__GAS_LIMIT_EXCEEDED]: `Gas limit exceeded`,
     [BASE_RELAYER_ERROR__GAS_LIMIT_TOO_LOW]: `Gas limit too low`,
+    [BASE_RELAYER_ERROR__INCORRECT_GAS_FEE_RECEIVER]: `Incorrect gas fee receiver`,
+    [BASE_RELAYER_ERROR__INCORRECT_RELAYER_PROGRAM]: `Incorrect relayer program`,
+    [BASE_RELAYER_ERROR__UNAUTHORIZED_CONFIG_UPDATE]: `Unauthorized to update configuration`,
+    [BASE_RELAYER_ERROR__UNAUTHORIZED_INITIALIZATION]: `Only the upgrade authority can initialize the relayer`,
   };
 }
 

--- a/clients/ts/src/bridge/generated/errors/bridge.ts
+++ b/clients/ts/src/bridge/generated/errors/bridge.ts
@@ -14,20 +14,188 @@ import {
 } from '@solana/kit';
 import { BRIDGE_PROGRAM_ADDRESS } from '../programs';
 
-/** MaxSizeExceeded: Call buffer size exceeds maximum allowed size */
-export const BRIDGE_ERROR__MAX_SIZE_EXCEEDED = 0x1770; // 6000
-/** InvalidBufferSize: Invalid buffer size provided */
-export const BRIDGE_ERROR__INVALID_BUFFER_SIZE = 0x1771; // 6001
+/** BridgePaused: Bridge is currently paused */
+export const BRIDGE_ERROR__BRIDGE_PAUSED = 0x2ee0; // 12000
+/** IncorrectBridgeProgram: Incorrect bridge program */
+export const BRIDGE_ERROR__INCORRECT_BRIDGE_PROGRAM = 0x2ee1; // 12001
+/** IncorrectGasFeeReceiver: Incorrect gas fee receiver */
+export const BRIDGE_ERROR__INCORRECT_GAS_FEE_RECEIVER = 0x2ee2; // 12002
+/** UnauthorizedInitialization: Only the upgrade authority can initialize the bridge */
+export const BRIDGE_ERROR__UNAUTHORIZED_INITIALIZATION = 0x2f44; // 12100
+/** UnauthorizedConfigUpdate: Unauthorized to update configuration */
+export const BRIDGE_ERROR__UNAUTHORIZED_CONFIG_UPDATE = 0x2f45; // 12101
+/** BufferUnauthorizedClose: Only the owner can close this buffer */
+export const BRIDGE_ERROR__BUFFER_UNAUTHORIZED_CLOSE = 0x2fa8; // 12200
+/** BufferUnauthorizedAppend: Only the owner can append to this buffer */
+export const BRIDGE_ERROR__BUFFER_UNAUTHORIZED_APPEND = 0x2fa9; // 12201
+/** BufferMaxSizeExceeded: Call buffer size exceeds maximum allowed size */
+export const BRIDGE_ERROR__BUFFER_MAX_SIZE_EXCEEDED = 0x2faa; // 12202
+/** InvalidRecoveryId: Invalid recovery ID */
+export const BRIDGE_ERROR__INVALID_RECOVERY_ID = 0x300c; // 12300
+/** SignatureVerificationFailed: Signature verification failed */
+export const BRIDGE_ERROR__SIGNATURE_VERIFICATION_FAILED = 0x300d; // 12301
+/** InsufficientBaseSignatures: Insufficient base oracle signatures to meet threshold */
+export const BRIDGE_ERROR__INSUFFICIENT_BASE_SIGNATURES = 0x300e; // 12302
+/** InsufficientPartnerSignatures: Insufficient partner oracle signatures to meet threshold */
+export const BRIDGE_ERROR__INSUFFICIENT_PARTNER_SIGNATURES = 0x300f; // 12303
+/** InvalidProof: Invalid proof */
+export const BRIDGE_ERROR__INVALID_PROOF = 0x3070; // 12400
+/** MmrShouldBeEmpty: MMR should be empty */
+export const BRIDGE_ERROR__MMR_SHOULD_BE_EMPTY = 0x3071; // 12401
+/** EmptyMmr: MMR is empty */
+export const BRIDGE_ERROR__EMPTY_MMR = 0x3072; // 12402
+/** LeafMountainNotFound: Leaf's mountain not found */
+export const BRIDGE_ERROR__LEAF_MOUNTAIN_NOT_FOUND = 0x3073; // 12403
+/** InsufficientProofElementsForIntraMountainPath: Insufficient proof elements for intra-mountain path */
+export const BRIDGE_ERROR__INSUFFICIENT_PROOF_ELEMENTS_FOR_INTRA_MOUNTAIN_PATH = 0x3074; // 12404
+/** InsufficientProofElementsForOtherMountainPeaks: Insufficient proof elements for other mountain peaks */
+export const BRIDGE_ERROR__INSUFFICIENT_PROOF_ELEMENTS_FOR_OTHER_MOUNTAIN_PEAKS = 0x3075; // 12405
+/** UnusedProofElementsRemaining: Unused proof elements remaining */
+export const BRIDGE_ERROR__UNUSED_PROOF_ELEMENTS_REMAINING = 0x3076; // 12406
+/** NoPeaksFoundForNonEmptyMmr: No peaks found for non-empty MMR */
+export const BRIDGE_ERROR__NO_PEAKS_FOUND_FOR_NON_EMPTY_MMR = 0x3077; // 12407
+/** InvalidMessageHash: Invalid message hash */
+export const BRIDGE_ERROR__INVALID_MESSAGE_HASH = 0x30d4; // 12500
+/** AlreadyExecuted: Message already executed */
+export const BRIDGE_ERROR__ALREADY_EXECUTED = 0x30d5; // 12501
+/** IncorrectBlockNumber: Incorrect block number */
+export const BRIDGE_ERROR__INCORRECT_BLOCK_NUMBER = 0x30d6; // 12502
+/** MintDoesNotMatchLocalToken: Mint does not match local token */
+export const BRIDGE_ERROR__MINT_DOES_NOT_MATCH_LOCAL_TOKEN = 0x3138; // 12600
+/** TokenAccountDoesNotMatchTo: Token account does not match to address */
+export const BRIDGE_ERROR__TOKEN_ACCOUNT_DOES_NOT_MATCH_TO = 0x3139; // 12601
+/** IncorrectTokenVault: Incorrect token vault */
+export const BRIDGE_ERROR__INCORRECT_TOKEN_VAULT = 0x313a; // 12602
+/** MintIsWrappedToken: Mint is a wrapped token */
+export const BRIDGE_ERROR__MINT_IS_WRAPPED_TOKEN = 0x313b; // 12603
+/** IncorrectTo: Incorrect to */
+export const BRIDGE_ERROR__INCORRECT_TO = 0x313c; // 12604
+/** IncorrectSolVault: Incorrect sol vault */
+export const BRIDGE_ERROR__INCORRECT_SOL_VAULT = 0x313d; // 12605
+/** RemoteTokenNotFound: Remote token not found */
+export const BRIDGE_ERROR__REMOTE_TOKEN_NOT_FOUND = 0x319c; // 12700
+/** ScalerExponentNotFound: Scaler exponent not found */
+export const BRIDGE_ERROR__SCALER_EXPONENT_NOT_FOUND = 0x319d; // 12701
+/** InvalidRemoteToken: Invalid remote token */
+export const BRIDGE_ERROR__INVALID_REMOTE_TOKEN = 0x319e; // 12702
+/** InvalidScalerExponent: Invalid scaler exponent */
+export const BRIDGE_ERROR__INVALID_SCALER_EXPONENT = 0x319f; // 12703
+/** MintIsNotFromToken2022: Mint is not a token 2022 mint */
+export const BRIDGE_ERROR__MINT_IS_NOT_FROM_TOKEN2022 = 0x31a0; // 12704
+/** MintIsNotWrappedTokenPda: Mint is not a valid wrapped token PDA */
+export const BRIDGE_ERROR__MINT_IS_NOT_WRAPPED_TOKEN_PDA = 0x31a1; // 12705
+/** InvalidThreshold: Threshold must be <= number of signers */
+export const BRIDGE_ERROR__INVALID_THRESHOLD = 0x3200; // 12800
+/** TooManySigners: Too many signers (max 32) */
+export const BRIDGE_ERROR__TOO_MANY_SIGNERS = 0x3201; // 12801
+/** DuplicateSigner: Duplicate signer found */
+export const BRIDGE_ERROR__DUPLICATE_SIGNER = 0x3202; // 12802
+/** InvalidPartnerThreshold: Invalid partner threshold */
+export const BRIDGE_ERROR__INVALID_PARTNER_THRESHOLD = 0x3203; // 12803
+/** InvalidDenominator: Invalid denominator */
+export const BRIDGE_ERROR__INVALID_DENOMINATOR = 0x3204; // 12804
+/** InvalidWindowDurationSeconds: Invalid window duration seconds */
+export const BRIDGE_ERROR__INVALID_WINDOW_DURATION_SECONDS = 0x3205; // 12805
+/** InvalidGasCostScalerDp: Invalid gas cost scaler dp */
+export const BRIDGE_ERROR__INVALID_GAS_COST_SCALER_DP = 0x3206; // 12806
+/** InvalidBlockIntervalRequirement: Invalid block interval requirement */
+export const BRIDGE_ERROR__INVALID_BLOCK_INTERVAL_REQUIREMENT = 0x3207; // 12807
+/** CreationWithNonZeroTarget: Creation with non-zero target */
+export const BRIDGE_ERROR__CREATION_WITH_NON_ZERO_TARGET = 0x3264; // 12900
 
 export type BridgeError =
-  | typeof BRIDGE_ERROR__INVALID_BUFFER_SIZE
-  | typeof BRIDGE_ERROR__MAX_SIZE_EXCEEDED;
+  | typeof BRIDGE_ERROR__ALREADY_EXECUTED
+  | typeof BRIDGE_ERROR__BRIDGE_PAUSED
+  | typeof BRIDGE_ERROR__BUFFER_MAX_SIZE_EXCEEDED
+  | typeof BRIDGE_ERROR__BUFFER_UNAUTHORIZED_APPEND
+  | typeof BRIDGE_ERROR__BUFFER_UNAUTHORIZED_CLOSE
+  | typeof BRIDGE_ERROR__CREATION_WITH_NON_ZERO_TARGET
+  | typeof BRIDGE_ERROR__DUPLICATE_SIGNER
+  | typeof BRIDGE_ERROR__EMPTY_MMR
+  | typeof BRIDGE_ERROR__INCORRECT_BLOCK_NUMBER
+  | typeof BRIDGE_ERROR__INCORRECT_BRIDGE_PROGRAM
+  | typeof BRIDGE_ERROR__INCORRECT_GAS_FEE_RECEIVER
+  | typeof BRIDGE_ERROR__INCORRECT_SOL_VAULT
+  | typeof BRIDGE_ERROR__INCORRECT_TO
+  | typeof BRIDGE_ERROR__INCORRECT_TOKEN_VAULT
+  | typeof BRIDGE_ERROR__INSUFFICIENT_BASE_SIGNATURES
+  | typeof BRIDGE_ERROR__INSUFFICIENT_PARTNER_SIGNATURES
+  | typeof BRIDGE_ERROR__INSUFFICIENT_PROOF_ELEMENTS_FOR_INTRA_MOUNTAIN_PATH
+  | typeof BRIDGE_ERROR__INSUFFICIENT_PROOF_ELEMENTS_FOR_OTHER_MOUNTAIN_PEAKS
+  | typeof BRIDGE_ERROR__INVALID_BLOCK_INTERVAL_REQUIREMENT
+  | typeof BRIDGE_ERROR__INVALID_DENOMINATOR
+  | typeof BRIDGE_ERROR__INVALID_GAS_COST_SCALER_DP
+  | typeof BRIDGE_ERROR__INVALID_MESSAGE_HASH
+  | typeof BRIDGE_ERROR__INVALID_PARTNER_THRESHOLD
+  | typeof BRIDGE_ERROR__INVALID_PROOF
+  | typeof BRIDGE_ERROR__INVALID_RECOVERY_ID
+  | typeof BRIDGE_ERROR__INVALID_REMOTE_TOKEN
+  | typeof BRIDGE_ERROR__INVALID_SCALER_EXPONENT
+  | typeof BRIDGE_ERROR__INVALID_THRESHOLD
+  | typeof BRIDGE_ERROR__INVALID_WINDOW_DURATION_SECONDS
+  | typeof BRIDGE_ERROR__LEAF_MOUNTAIN_NOT_FOUND
+  | typeof BRIDGE_ERROR__MINT_DOES_NOT_MATCH_LOCAL_TOKEN
+  | typeof BRIDGE_ERROR__MINT_IS_NOT_FROM_TOKEN2022
+  | typeof BRIDGE_ERROR__MINT_IS_NOT_WRAPPED_TOKEN_PDA
+  | typeof BRIDGE_ERROR__MINT_IS_WRAPPED_TOKEN
+  | typeof BRIDGE_ERROR__MMR_SHOULD_BE_EMPTY
+  | typeof BRIDGE_ERROR__NO_PEAKS_FOUND_FOR_NON_EMPTY_MMR
+  | typeof BRIDGE_ERROR__REMOTE_TOKEN_NOT_FOUND
+  | typeof BRIDGE_ERROR__SCALER_EXPONENT_NOT_FOUND
+  | typeof BRIDGE_ERROR__SIGNATURE_VERIFICATION_FAILED
+  | typeof BRIDGE_ERROR__TOKEN_ACCOUNT_DOES_NOT_MATCH_TO
+  | typeof BRIDGE_ERROR__TOO_MANY_SIGNERS
+  | typeof BRIDGE_ERROR__UNAUTHORIZED_CONFIG_UPDATE
+  | typeof BRIDGE_ERROR__UNAUTHORIZED_INITIALIZATION
+  | typeof BRIDGE_ERROR__UNUSED_PROOF_ELEMENTS_REMAINING;
 
 let bridgeErrorMessages: Record<BridgeError, string> | undefined;
 if (process.env.NODE_ENV !== 'production') {
   bridgeErrorMessages = {
-    [BRIDGE_ERROR__INVALID_BUFFER_SIZE]: `Invalid buffer size provided`,
-    [BRIDGE_ERROR__MAX_SIZE_EXCEEDED]: `Call buffer size exceeds maximum allowed size`,
+    [BRIDGE_ERROR__ALREADY_EXECUTED]: `Message already executed`,
+    [BRIDGE_ERROR__BRIDGE_PAUSED]: `Bridge is currently paused`,
+    [BRIDGE_ERROR__BUFFER_MAX_SIZE_EXCEEDED]: `Call buffer size exceeds maximum allowed size`,
+    [BRIDGE_ERROR__BUFFER_UNAUTHORIZED_APPEND]: `Only the owner can append to this buffer`,
+    [BRIDGE_ERROR__BUFFER_UNAUTHORIZED_CLOSE]: `Only the owner can close this buffer`,
+    [BRIDGE_ERROR__CREATION_WITH_NON_ZERO_TARGET]: `Creation with non-zero target`,
+    [BRIDGE_ERROR__DUPLICATE_SIGNER]: `Duplicate signer found`,
+    [BRIDGE_ERROR__EMPTY_MMR]: `MMR is empty`,
+    [BRIDGE_ERROR__INCORRECT_BLOCK_NUMBER]: `Incorrect block number`,
+    [BRIDGE_ERROR__INCORRECT_BRIDGE_PROGRAM]: `Incorrect bridge program`,
+    [BRIDGE_ERROR__INCORRECT_GAS_FEE_RECEIVER]: `Incorrect gas fee receiver`,
+    [BRIDGE_ERROR__INCORRECT_SOL_VAULT]: `Incorrect sol vault`,
+    [BRIDGE_ERROR__INCORRECT_TO]: `Incorrect to`,
+    [BRIDGE_ERROR__INCORRECT_TOKEN_VAULT]: `Incorrect token vault`,
+    [BRIDGE_ERROR__INSUFFICIENT_BASE_SIGNATURES]: `Insufficient base oracle signatures to meet threshold`,
+    [BRIDGE_ERROR__INSUFFICIENT_PARTNER_SIGNATURES]: `Insufficient partner oracle signatures to meet threshold`,
+    [BRIDGE_ERROR__INSUFFICIENT_PROOF_ELEMENTS_FOR_INTRA_MOUNTAIN_PATH]: `Insufficient proof elements for intra-mountain path`,
+    [BRIDGE_ERROR__INSUFFICIENT_PROOF_ELEMENTS_FOR_OTHER_MOUNTAIN_PEAKS]: `Insufficient proof elements for other mountain peaks`,
+    [BRIDGE_ERROR__INVALID_BLOCK_INTERVAL_REQUIREMENT]: `Invalid block interval requirement`,
+    [BRIDGE_ERROR__INVALID_DENOMINATOR]: `Invalid denominator`,
+    [BRIDGE_ERROR__INVALID_GAS_COST_SCALER_DP]: `Invalid gas cost scaler dp`,
+    [BRIDGE_ERROR__INVALID_MESSAGE_HASH]: `Invalid message hash`,
+    [BRIDGE_ERROR__INVALID_PARTNER_THRESHOLD]: `Invalid partner threshold`,
+    [BRIDGE_ERROR__INVALID_PROOF]: `Invalid proof`,
+    [BRIDGE_ERROR__INVALID_RECOVERY_ID]: `Invalid recovery ID`,
+    [BRIDGE_ERROR__INVALID_REMOTE_TOKEN]: `Invalid remote token`,
+    [BRIDGE_ERROR__INVALID_SCALER_EXPONENT]: `Invalid scaler exponent`,
+    [BRIDGE_ERROR__INVALID_THRESHOLD]: `Threshold must be <= number of signers`,
+    [BRIDGE_ERROR__INVALID_WINDOW_DURATION_SECONDS]: `Invalid window duration seconds`,
+    [BRIDGE_ERROR__LEAF_MOUNTAIN_NOT_FOUND]: `Leaf's mountain not found`,
+    [BRIDGE_ERROR__MINT_DOES_NOT_MATCH_LOCAL_TOKEN]: `Mint does not match local token`,
+    [BRIDGE_ERROR__MINT_IS_NOT_FROM_TOKEN2022]: `Mint is not a token 2022 mint`,
+    [BRIDGE_ERROR__MINT_IS_NOT_WRAPPED_TOKEN_PDA]: `Mint is not a valid wrapped token PDA`,
+    [BRIDGE_ERROR__MINT_IS_WRAPPED_TOKEN]: `Mint is a wrapped token`,
+    [BRIDGE_ERROR__MMR_SHOULD_BE_EMPTY]: `MMR should be empty`,
+    [BRIDGE_ERROR__NO_PEAKS_FOUND_FOR_NON_EMPTY_MMR]: `No peaks found for non-empty MMR`,
+    [BRIDGE_ERROR__REMOTE_TOKEN_NOT_FOUND]: `Remote token not found`,
+    [BRIDGE_ERROR__SCALER_EXPONENT_NOT_FOUND]: `Scaler exponent not found`,
+    [BRIDGE_ERROR__SIGNATURE_VERIFICATION_FAILED]: `Signature verification failed`,
+    [BRIDGE_ERROR__TOKEN_ACCOUNT_DOES_NOT_MATCH_TO]: `Token account does not match to address`,
+    [BRIDGE_ERROR__TOO_MANY_SIGNERS]: `Too many signers (max 32)`,
+    [BRIDGE_ERROR__UNAUTHORIZED_CONFIG_UPDATE]: `Unauthorized to update configuration`,
+    [BRIDGE_ERROR__UNAUTHORIZED_INITIALIZATION]: `Only the upgrade authority can initialize the bridge`,
+    [BRIDGE_ERROR__UNUSED_PROOF_ELEMENTS_REMAINING]: `Unused proof elements remaining`,
   };
 }
 

--- a/clients/ts/src/bridge/generated/instructions/initialize.ts
+++ b/clients/ts/src/bridge/generated/instructions/initialize.ts
@@ -10,6 +10,8 @@ import {
   combineCodec,
   fixDecoderSize,
   fixEncoderSize,
+  getAddressDecoder,
+  getAddressEncoder,
   getBytesDecoder,
   getBytesEncoder,
   getStructDecoder,
@@ -70,9 +72,11 @@ export function getInitializeDiscriminatorBytes() {
 
 export type InitializeInstruction<
   TProgram extends string = typeof BRIDGE_PROGRAM_ADDRESS,
+  TAccountUpgradeAuthority extends string | AccountMeta<string> = string,
   TAccountPayer extends string | AccountMeta<string> = string,
   TAccountBridge extends string | AccountMeta<string> = string,
-  TAccountGuardian extends string | AccountMeta<string> = string,
+  TAccountProgramData extends string | AccountMeta<string> = string,
+  TAccountProgram extends string | AccountMeta<string> = string,
   TAccountSystemProgram extends
     | string
     | AccountMeta<string> = '11111111111111111111111111111111',
@@ -81,6 +85,10 @@ export type InitializeInstruction<
   InstructionWithData<ReadonlyUint8Array> &
   InstructionWithAccounts<
     [
+      TAccountUpgradeAuthority extends string
+        ? ReadonlySignerAccount<TAccountUpgradeAuthority> &
+            AccountSignerMeta<TAccountUpgradeAuthority>
+        : TAccountUpgradeAuthority,
       TAccountPayer extends string
         ? WritableSignerAccount<TAccountPayer> &
             AccountSignerMeta<TAccountPayer>
@@ -88,10 +96,12 @@ export type InitializeInstruction<
       TAccountBridge extends string
         ? WritableAccount<TAccountBridge>
         : TAccountBridge,
-      TAccountGuardian extends string
-        ? ReadonlySignerAccount<TAccountGuardian> &
-            AccountSignerMeta<TAccountGuardian>
-        : TAccountGuardian,
+      TAccountProgramData extends string
+        ? ReadonlyAccount<TAccountProgramData>
+        : TAccountProgramData,
+      TAccountProgram extends string
+        ? ReadonlyAccount<TAccountProgram>
+        : TAccountProgram,
       TAccountSystemProgram extends string
         ? ReadonlyAccount<TAccountSystemProgram>
         : TAccountSystemProgram,
@@ -101,6 +111,7 @@ export type InitializeInstruction<
 
 export type InitializeInstructionData = {
   discriminator: ReadonlyUint8Array;
+  guardian: Address;
   /** Configuration parameters for EIP-1559-inspired fee calculations */
   eip1559Config: Eip1559Config;
   /** Configuration parameters for outgoing message pricing */
@@ -116,6 +127,7 @@ export type InitializeInstructionData = {
 };
 
 export type InitializeInstructionDataArgs = {
+  guardian: Address;
   /** Configuration parameters for EIP-1559-inspired fee calculations */
   eip1559Config: Eip1559ConfigArgs;
   /** Configuration parameters for outgoing message pricing */
@@ -134,6 +146,7 @@ export function getInitializeInstructionDataEncoder(): FixedSizeEncoder<Initiali
   return transformEncoder(
     getStructEncoder([
       ['discriminator', fixEncoderSize(getBytesEncoder(), 8)],
+      ['guardian', getAddressEncoder()],
       ['eip1559Config', getEip1559ConfigEncoder()],
       ['gasConfig', getGasConfigEncoder()],
       ['protocolConfig', getProtocolConfigEncoder()],
@@ -148,6 +161,7 @@ export function getInitializeInstructionDataEncoder(): FixedSizeEncoder<Initiali
 export function getInitializeInstructionDataDecoder(): FixedSizeDecoder<InitializeInstructionData> {
   return getStructDecoder([
     ['discriminator', fixDecoderSize(getBytesDecoder(), 8)],
+    ['guardian', getAddressDecoder()],
     ['eip1559Config', getEip1559ConfigDecoder()],
     ['gasConfig', getGasConfigDecoder()],
     ['protocolConfig', getProtocolConfigDecoder()],
@@ -168,14 +182,22 @@ export function getInitializeInstructionDataCodec(): FixedSizeCodec<
 }
 
 export type InitializeInput<
+  TAccountUpgradeAuthority extends string = string,
   TAccountPayer extends string = string,
   TAccountBridge extends string = string,
-  TAccountGuardian extends string = string,
+  TAccountProgramData extends string = string,
+  TAccountProgram extends string = string,
   TAccountSystemProgram extends string = string,
 > = {
   /**
+   * The upgrade authority that is authorized to initialize the bridge.
+   * This ensures only the program deployer can set the initial configuration.
+   */
+  upgradeAuthority: TransactionSigner<TAccountUpgradeAuthority>;
+  /**
    * The account that pays for the transaction and bridge account creation.
    * Must be mutable to deduct lamports for account rent.
+   * Can be different from the upgrade_authority.
    */
   payer: TransactionSigner<TAccountPayer>;
   /**
@@ -186,16 +208,21 @@ export type InitializeInput<
    */
   bridge: Address<TAccountBridge>;
   /**
-   * The guardian account that will have administrative authority over the bridge.
-   * Must be a signer to prove ownership of the guardian key. The payer and guardian
-   * may be distinct signers.
+   * Program data account containing the upgrade authority.
+   * Validates that the signer is indeed the upgrade authority.
    */
-  guardian: TransactionSigner<TAccountGuardian>;
+  programData: Address<TAccountProgramData>;
+  /**
+   * The bridge program itself.
+   * Validates that program_data is the correct ProgramData account for this program.
+   */
+  program: Address<TAccountProgram>;
   /**
    * System program required for creating new accounts.
    * Used internally by Anchor for account initialization.
    */
   systemProgram?: Address<TAccountSystemProgram>;
+  guardian: InitializeInstructionDataArgs['guardian'];
   eip1559Config: InitializeInstructionDataArgs['eip1559Config'];
   gasConfig: InitializeInstructionDataArgs['gasConfig'];
   protocolConfig: InitializeInstructionDataArgs['protocolConfig'];
@@ -205,24 +232,30 @@ export type InitializeInput<
 };
 
 export function getInitializeInstruction<
+  TAccountUpgradeAuthority extends string,
   TAccountPayer extends string,
   TAccountBridge extends string,
-  TAccountGuardian extends string,
+  TAccountProgramData extends string,
+  TAccountProgram extends string,
   TAccountSystemProgram extends string,
   TProgramAddress extends Address = typeof BRIDGE_PROGRAM_ADDRESS,
 >(
   input: InitializeInput<
+    TAccountUpgradeAuthority,
     TAccountPayer,
     TAccountBridge,
-    TAccountGuardian,
+    TAccountProgramData,
+    TAccountProgram,
     TAccountSystemProgram
   >,
   config?: { programAddress?: TProgramAddress }
 ): InitializeInstruction<
   TProgramAddress,
+  TAccountUpgradeAuthority,
   TAccountPayer,
   TAccountBridge,
-  TAccountGuardian,
+  TAccountProgramData,
+  TAccountProgram,
   TAccountSystemProgram
 > {
   // Program address.
@@ -230,9 +263,14 @@ export function getInitializeInstruction<
 
   // Original accounts.
   const originalAccounts = {
+    upgradeAuthority: {
+      value: input.upgradeAuthority ?? null,
+      isWritable: false,
+    },
     payer: { value: input.payer ?? null, isWritable: true },
     bridge: { value: input.bridge ?? null, isWritable: true },
-    guardian: { value: input.guardian ?? null, isWritable: false },
+    programData: { value: input.programData ?? null, isWritable: false },
+    program: { value: input.program ?? null, isWritable: false },
     systemProgram: { value: input.systemProgram ?? null, isWritable: false },
   };
   const accounts = originalAccounts as Record<
@@ -252,9 +290,11 @@ export function getInitializeInstruction<
   const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
   return Object.freeze({
     accounts: [
+      getAccountMeta(accounts.upgradeAuthority),
       getAccountMeta(accounts.payer),
       getAccountMeta(accounts.bridge),
-      getAccountMeta(accounts.guardian),
+      getAccountMeta(accounts.programData),
+      getAccountMeta(accounts.program),
       getAccountMeta(accounts.systemProgram),
     ],
     data: getInitializeInstructionDataEncoder().encode(
@@ -263,9 +303,11 @@ export function getInitializeInstruction<
     programAddress,
   } as InitializeInstruction<
     TProgramAddress,
+    TAccountUpgradeAuthority,
     TAccountPayer,
     TAccountBridge,
-    TAccountGuardian,
+    TAccountProgramData,
+    TAccountProgram,
     TAccountSystemProgram
   >);
 }
@@ -277,28 +319,38 @@ export type ParsedInitializeInstruction<
   programAddress: Address<TProgram>;
   accounts: {
     /**
+     * The upgrade authority that is authorized to initialize the bridge.
+     * This ensures only the program deployer can set the initial configuration.
+     */
+    upgradeAuthority: TAccountMetas[0];
+    /**
      * The account that pays for the transaction and bridge account creation.
      * Must be mutable to deduct lamports for account rent.
+     * Can be different from the upgrade_authority.
      */
-    payer: TAccountMetas[0];
+    payer: TAccountMetas[1];
     /**
      * The bridge state account being initialized.
      * - Uses PDA with BRIDGE_SEED for deterministic address
      * - Payer funds the account creation
      * - Space allocated for bridge state (DISCRIMINATOR_LEN + Bridge::INIT_SPACE)
      */
-    bridge: TAccountMetas[1];
+    bridge: TAccountMetas[2];
     /**
-     * The guardian account that will have administrative authority over the bridge.
-     * Must be a signer to prove ownership of the guardian key. The payer and guardian
-     * may be distinct signers.
+     * Program data account containing the upgrade authority.
+     * Validates that the signer is indeed the upgrade authority.
      */
-    guardian: TAccountMetas[2];
+    programData: TAccountMetas[3];
+    /**
+     * The bridge program itself.
+     * Validates that program_data is the correct ProgramData account for this program.
+     */
+    program: TAccountMetas[4];
     /**
      * System program required for creating new accounts.
      * Used internally by Anchor for account initialization.
      */
-    systemProgram: TAccountMetas[3];
+    systemProgram: TAccountMetas[5];
   };
   data: InitializeInstructionData;
 };
@@ -311,7 +363,7 @@ export function parseInitializeInstruction<
     InstructionWithAccounts<TAccountMetas> &
     InstructionWithData<ReadonlyUint8Array>
 ): ParsedInitializeInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 4) {
+  if (instruction.accounts.length < 6) {
     // TODO: Coded error.
     throw new Error('Not enough accounts');
   }
@@ -324,9 +376,11 @@ export function parseInitializeInstruction<
   return {
     programAddress: instruction.programAddress,
     accounts: {
+      upgradeAuthority: getNextAccount(),
       payer: getNextAccount(),
       bridge: getNextAccount(),
-      guardian: getNextAccount(),
+      programData: getNextAccount(),
+      program: getNextAccount(),
       systemProgram: getNextAccount(),
     },
     data: getInitializeInstructionDataDecoder().decode(instruction.data),

--- a/clients/ts/src/bridge/generated/instructions/setPartnerOracleConfig.ts
+++ b/clients/ts/src/bridge/generated/instructions/setPartnerOracleConfig.ts
@@ -24,6 +24,7 @@ import {
   type Instruction,
   type InstructionWithAccounts,
   type InstructionWithData,
+  type ReadonlyAccount,
   type ReadonlySignerAccount,
   type ReadonlyUint8Array,
   type TransactionSigner,
@@ -50,20 +51,28 @@ export function getSetPartnerOracleConfigDiscriminatorBytes() {
 
 export type SetPartnerOracleConfigInstruction<
   TProgram extends string = typeof BRIDGE_PROGRAM_ADDRESS,
+  TAccountUpgradeAuthority extends string | AccountMeta<string> = string,
   TAccountBridge extends string | AccountMeta<string> = string,
-  TAccountGuardian extends string | AccountMeta<string> = string,
+  TAccountProgramData extends string | AccountMeta<string> = string,
+  TAccountProgram extends string | AccountMeta<string> = string,
   TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
   InstructionWithData<ReadonlyUint8Array> &
   InstructionWithAccounts<
     [
+      TAccountUpgradeAuthority extends string
+        ? ReadonlySignerAccount<TAccountUpgradeAuthority> &
+            AccountSignerMeta<TAccountUpgradeAuthority>
+        : TAccountUpgradeAuthority,
       TAccountBridge extends string
         ? WritableAccount<TAccountBridge>
         : TAccountBridge,
-      TAccountGuardian extends string
-        ? ReadonlySignerAccount<TAccountGuardian> &
-            AccountSignerMeta<TAccountGuardian>
-        : TAccountGuardian,
+      TAccountProgramData extends string
+        ? ReadonlyAccount<TAccountProgramData>
+        : TAccountProgramData,
+      TAccountProgram extends string
+        ? ReadonlyAccount<TAccountProgram>
+        : TAccountProgram,
       ...TRemainingAccounts,
     ]
   >;
@@ -108,35 +117,53 @@ export function getSetPartnerOracleConfigInstructionDataCodec(): FixedSizeCodec<
 }
 
 export type SetPartnerOracleConfigInput<
+  TAccountUpgradeAuthority extends string = string,
   TAccountBridge extends string = string,
-  TAccountGuardian extends string = string,
+  TAccountProgramData extends string = string,
+  TAccountProgram extends string = string,
 > = {
+  /** The upgrade authority account */
+  upgradeAuthority: TransactionSigner<TAccountUpgradeAuthority>;
   /** The bridge account containing configuration */
   bridge: Address<TAccountBridge>;
-  /** The guardian account authorized to update configuration */
-  guardian: TransactionSigner<TAccountGuardian>;
+  programData: Address<TAccountProgramData>;
+  program: Address<TAccountProgram>;
   newConfig: SetPartnerOracleConfigInstructionDataArgs['newConfig'];
 };
 
 export function getSetPartnerOracleConfigInstruction<
+  TAccountUpgradeAuthority extends string,
   TAccountBridge extends string,
-  TAccountGuardian extends string,
+  TAccountProgramData extends string,
+  TAccountProgram extends string,
   TProgramAddress extends Address = typeof BRIDGE_PROGRAM_ADDRESS,
 >(
-  input: SetPartnerOracleConfigInput<TAccountBridge, TAccountGuardian>,
+  input: SetPartnerOracleConfigInput<
+    TAccountUpgradeAuthority,
+    TAccountBridge,
+    TAccountProgramData,
+    TAccountProgram
+  >,
   config?: { programAddress?: TProgramAddress }
 ): SetPartnerOracleConfigInstruction<
   TProgramAddress,
+  TAccountUpgradeAuthority,
   TAccountBridge,
-  TAccountGuardian
+  TAccountProgramData,
+  TAccountProgram
 > {
   // Program address.
   const programAddress = config?.programAddress ?? BRIDGE_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
+    upgradeAuthority: {
+      value: input.upgradeAuthority ?? null,
+      isWritable: false,
+    },
     bridge: { value: input.bridge ?? null, isWritable: true },
-    guardian: { value: input.guardian ?? null, isWritable: false },
+    programData: { value: input.programData ?? null, isWritable: false },
+    program: { value: input.program ?? null, isWritable: false },
   };
   const accounts = originalAccounts as Record<
     keyof typeof originalAccounts,
@@ -149,8 +176,10 @@ export function getSetPartnerOracleConfigInstruction<
   const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
   return Object.freeze({
     accounts: [
+      getAccountMeta(accounts.upgradeAuthority),
       getAccountMeta(accounts.bridge),
-      getAccountMeta(accounts.guardian),
+      getAccountMeta(accounts.programData),
+      getAccountMeta(accounts.program),
     ],
     data: getSetPartnerOracleConfigInstructionDataEncoder().encode(
       args as SetPartnerOracleConfigInstructionDataArgs
@@ -158,8 +187,10 @@ export function getSetPartnerOracleConfigInstruction<
     programAddress,
   } as SetPartnerOracleConfigInstruction<
     TProgramAddress,
+    TAccountUpgradeAuthority,
     TAccountBridge,
-    TAccountGuardian
+    TAccountProgramData,
+    TAccountProgram
   >);
 }
 
@@ -169,10 +200,12 @@ export type ParsedSetPartnerOracleConfigInstruction<
 > = {
   programAddress: Address<TProgram>;
   accounts: {
+    /** The upgrade authority account */
+    upgradeAuthority: TAccountMetas[0];
     /** The bridge account containing configuration */
-    bridge: TAccountMetas[0];
-    /** The guardian account authorized to update configuration */
-    guardian: TAccountMetas[1];
+    bridge: TAccountMetas[1];
+    programData: TAccountMetas[2];
+    program: TAccountMetas[3];
   };
   data: SetPartnerOracleConfigInstructionData;
 };
@@ -185,7 +218,7 @@ export function parseSetPartnerOracleConfigInstruction<
     InstructionWithAccounts<TAccountMetas> &
     InstructionWithData<ReadonlyUint8Array>
 ): ParsedSetPartnerOracleConfigInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 2) {
+  if (instruction.accounts.length < 4) {
     // TODO: Coded error.
     throw new Error('Not enough accounts');
   }
@@ -197,7 +230,12 @@ export function parseSetPartnerOracleConfigInstruction<
   };
   return {
     programAddress: instruction.programAddress,
-    accounts: { bridge: getNextAccount(), guardian: getNextAccount() },
+    accounts: {
+      upgradeAuthority: getNextAccount(),
+      bridge: getNextAccount(),
+      programData: getNextAccount(),
+      program: getNextAccount(),
+    },
     data: getSetPartnerOracleConfigInstructionDataDecoder().decode(
       instruction.data
     ),

--- a/scripts/src/commands/sol/base-relayer/initialize.command.ts
+++ b/scripts/src/commands/sol/base-relayer/initialize.command.ts
@@ -13,7 +13,7 @@ type CommanderOptions = {
   programId?: string;
   rpcUrl?: string;
   payerKp?: string;
-  guardianKp?: string;
+  guardian?: string;
   eip1559Target?: string;
   eip1559Denominator?: string;
   eip1559WindowDurationSeconds?: string;
@@ -65,9 +65,9 @@ async function collectInteractiveOptions(
     ["config"]
   );
 
-  opts.guardianKp = await getOrPromptFilePath(
-    opts.guardianKp,
-    "Enter guardian keypair path (or 'payer' for payer keypair)",
+  opts.guardian = await getOrPromptSolanaAddress(
+    opts.guardian,
+    "Enter guardian address (or 'payer' to use payer address)",
     ["payer"]
   );
 
@@ -124,8 +124,8 @@ export const initializeCommand = new Command("initialize")
     "Payer keypair: 'config' or custom payer keypair path"
   )
   .option(
-    "--guardian-kp <path>",
-    "Guardian keypair: 'payer' or custom guardian keypair path"
+    "--guardian <address>",
+    "Guardian address: 'payer' or Solana public key"
   )
   .option("--eip1559-target <uint>", "EIP-1559 target (bigint)")
   .option("--eip1559-denominator <uint>", "EIP-1559 denominator (bigint)")

--- a/scripts/src/commands/sol/bridge/initialize.command.ts
+++ b/scripts/src/commands/sol/bridge/initialize.command.ts
@@ -14,7 +14,7 @@ type CommanderOptions = {
   programId?: string;
   rpcUrl?: string;
   payerKp?: string;
-  guardianKp?: string;
+  guardian?: string;
   eip1559Target?: string;
   eip1559Denominator?: string;
   eip1559WindowDurationSeconds?: string;
@@ -71,9 +71,9 @@ async function collectInteractiveOptions(
     ["config"]
   );
 
-  opts.guardianKp = await getOrPromptFilePath(
-    opts.guardianKp,
-    "Enter guardian keypair path (or 'payer' for payer keypair)",
+  opts.guardian = await getOrPromptSolanaAddress(
+    opts.guardian,
+    "Enter guardian address (or 'payer' to use payer address)",
     ["payer"]
   );
 
@@ -154,8 +154,8 @@ export const initializeCommand = new Command("initialize")
     "Payer keypair: 'config' or custom payer keypair path"
   )
   .option(
-    "--guardian-kp <path>",
-    "Guardian keypair: 'payer' or custom guardian keypair path"
+    "--guardian <address>",
+    "Guardian address: 'payer' or Solana public key"
   )
   .option("--eip1559-target <uint>", "EIP-1559 target (bigint)")
   .option("--eip1559-denominator <uint>", "EIP-1559 denominator (bigint)")

--- a/scripts/src/internal/sol/base-relayer.idl.ts
+++ b/scripts/src/internal/sol/base-relayer.idl.ts
@@ -18,11 +18,12 @@ export const IDL = {
         "called once during deployment.",
         "",
         "# Arguments",
-        "* `ctx` - The context containing accounts for initialization: `payer` funds",
+        "* `ctx`            - The context containing accounts for initialization: `payer` funds",
         "account creation, `cfg` PDA is created with seeds, and `guardian`",
         "is recorded as the admin authority.",
-        "* `cfg` - Initial configuration values: guardian pubkey, EIP-1559 state and",
-        "config, and gas-cost configuration."
+        "* `guardian`       - The guardian address authorized to update configuration.",
+        "* `eip1559_config` - The EIP-1559 configuration.",
+        "* `gas_config`     - The gas configuration."
       ],
       "discriminator": [
         175,
@@ -36,10 +37,19 @@ export const IDL = {
       ],
       "accounts": [
         {
+          "name": "upgrade_authority",
+          "docs": [
+            "The upgrade authority that is authorized to initialize the relayer.",
+            "This ensures only the program deployer can set the initial configuration."
+          ],
+          "signer": true
+        },
+        {
           "name": "payer",
           "docs": [
-            "The account that pays for the transaction and bridge account creation.",
-            "Must be mutable to deduct lamports for account rent."
+            "The account that pays for the transaction and config account creation.",
+            "Must be mutable to deduct lamports for account rent.",
+            "Can be different from the upgrade_authority."
           ],
           "writable": true,
           "signer": true
@@ -49,18 +59,24 @@ export const IDL = {
           "docs": [
             "The relayer config state account that tracks fee parameters.",
             "- Uses PDA with CFG_SEED for deterministic address",
-            "- Mutable to update EIP1559 fee data"
+            "- Payer funds the account creation",
+            "- Space allocated for config state (DISCRIMINATOR_LEN + Cfg::INIT_SPACE)"
           ],
           "writable": true
         },
         {
-          "name": "guardian",
+          "name": "program_data",
           "docs": [
-            "The guardian account that will have administrative authority over the bridge.",
-            "Must be a signer to prove ownership of the guardian key. The payer and guardian",
-            "may be distinct signers."
-          ],
-          "signer": true
+            "Program data account containing the upgrade authority.",
+            "Validates that the signer is indeed the upgrade authority."
+          ]
+        },
+        {
+          "name": "program",
+          "docs": [
+            "The base_relayer program itself.",
+            "Validates that program_data is the correct ProgramData account for this program."
+          ]
         },
         {
           "name": "system_program",
@@ -72,7 +88,7 @@ export const IDL = {
       ],
       "args": [
         {
-          "name": "new_guardian",
+          "name": "guardian",
           "type": "pubkey"
         },
         {
@@ -357,14 +373,34 @@ export const IDL = {
   ],
   "errors": [
     {
-      "code": 6000,
+      "code": 12000,
+      "name": "UnauthorizedInitialization",
+      "msg": "Only the upgrade authority can initialize the relayer"
+    },
+    {
+      "code": 12001,
+      "name": "IncorrectRelayerProgram",
+      "msg": "Incorrect relayer program"
+    },
+    {
+      "code": 12100,
+      "name": "UnauthorizedConfigUpdate",
+      "msg": "Unauthorized to update configuration"
+    },
+    {
+      "code": 12200,
       "name": "GasLimitTooLow",
       "msg": "Gas limit too low"
     },
     {
-      "code": 6001,
+      "code": 12201,
       "name": "GasLimitExceeded",
       "msg": "Gas limit exceeded"
+    },
+    {
+      "code": 12300,
+      "name": "IncorrectGasFeeReceiver",
+      "msg": "Incorrect gas fee receiver"
     }
   ],
   "types": [

--- a/scripts/src/internal/sol/index.ts
+++ b/scripts/src/internal/sol/index.ts
@@ -4,5 +4,6 @@ export * from "./base";
 export * from "./bridge-idl.constants";
 export * from "./bridge";
 export * from "./key-pair";
+export * from "./loader-v3";
 export * from "./transaction";
 export * from "./types";

--- a/scripts/src/internal/sol/loader-v3.ts
+++ b/scripts/src/internal/sol/loader-v3.ts
@@ -1,0 +1,53 @@
+/**
+ * BPF Loader Upgradeable v3 Utilities
+ *
+ * Helper functions for working with Solana's BPF Loader Upgradeable program.
+ * Used to derive program data addresses and interact with upgradeable programs.
+ */
+
+import {
+  getProgramDerivedAddress,
+  address as solanaAddress,
+  getAddressEncoder,
+  type Address,
+} from "@solana/kit";
+
+/**
+ * The BPF Loader Upgradeable program address.
+ * This is the program that manages upgradeable Solana programs.
+ */
+export const BPF_UPGRADEABLE_LOADER_ADDRESS = solanaAddress(
+  "BPFLoaderUpgradeab1e11111111111111111111111"
+);
+
+/**
+ * Derives the Program Data Account (PDA) address for an upgradeable program.
+ *
+ * For upgradeable programs, the program address itself doesn't contain the upgrade authority.
+ * Instead, there's a separate Program Data Account that stores:
+ * - The upgrade authority public key
+ * - The program's executable data
+ * - Other metadata
+ *
+ * This PDA is derived using the BPF Loader Upgradeable program and the program's address as a seed.
+ *
+ * @param programAddress - The address of the upgradeable program
+ * @returns A Promise that resolves to the Program Data Account address
+ *
+ * @example
+ * ```typescript
+ * const bridgeProgramId = solanaAddress("BRG...");
+ * const programDataAddress = await getProgramDataAddress(bridgeProgramId);
+ * console.log(`Program data: ${programDataAddress}`);
+ * ```
+ */
+export async function getProgramDataAddress(
+  programAddress: Address
+): Promise<Address> {
+  const [programDataAddress] = await getProgramDerivedAddress({
+    programAddress: BPF_UPGRADEABLE_LOADER_ADDRESS,
+    seeds: [getAddressEncoder().encode(programAddress)],
+  });
+
+  return programDataAddress;
+}

--- a/solana/programs/base_relayer/idl.json
+++ b/solana/programs/base_relayer/idl.json
@@ -15,11 +15,12 @@
         "called once during deployment.",
         "",
         "# Arguments",
-        "* `ctx` - The context containing accounts for initialization: `payer` funds",
+        "* `ctx`            - The context containing accounts for initialization: `payer` funds",
         "account creation, `cfg` PDA is created with seeds, and `guardian`",
         "is recorded as the admin authority.",
-        "* `cfg` - Initial configuration values: guardian pubkey, EIP-1559 state and",
-        "config, and gas-cost configuration."
+        "* `guardian`       - The guardian address authorized to update configuration.",
+        "* `eip1559_config` - The EIP-1559 configuration.",
+        "* `gas_config`     - The gas configuration."
       ],
       "discriminator": [
         175,
@@ -33,10 +34,19 @@
       ],
       "accounts": [
         {
+          "name": "upgrade_authority",
+          "docs": [
+            "The upgrade authority that is authorized to initialize the relayer.",
+            "This ensures only the program deployer can set the initial configuration."
+          ],
+          "signer": true
+        },
+        {
           "name": "payer",
           "docs": [
-            "The account that pays for the transaction and bridge account creation.",
-            "Must be mutable to deduct lamports for account rent."
+            "The account that pays for the transaction and config account creation.",
+            "Must be mutable to deduct lamports for account rent.",
+            "Can be different from the upgrade_authority."
           ],
           "writable": true,
           "signer": true
@@ -46,18 +56,24 @@
           "docs": [
             "The relayer config state account that tracks fee parameters.",
             "- Uses PDA with CFG_SEED for deterministic address",
-            "- Mutable to update EIP1559 fee data"
+            "- Payer funds the account creation",
+            "- Space allocated for config state (DISCRIMINATOR_LEN + Cfg::INIT_SPACE)"
           ],
           "writable": true
         },
         {
-          "name": "guardian",
+          "name": "program_data",
           "docs": [
-            "The guardian account that will have administrative authority over the bridge.",
-            "Must be a signer to prove ownership of the guardian key. The payer and guardian",
-            "may be distinct signers."
-          ],
-          "signer": true
+            "Program data account containing the upgrade authority.",
+            "Validates that the signer is indeed the upgrade authority."
+          ]
+        },
+        {
+          "name": "program",
+          "docs": [
+            "The base_relayer program itself.",
+            "Validates that program_data is the correct ProgramData account for this program."
+          ]
         },
         {
           "name": "system_program",
@@ -69,7 +85,7 @@
       ],
       "args": [
         {
-          "name": "new_guardian",
+          "name": "guardian",
           "type": "pubkey"
         },
         {
@@ -354,14 +370,34 @@
   ],
   "errors": [
     {
-      "code": 6000,
+      "code": 12000,
+      "name": "UnauthorizedInitialization",
+      "msg": "Only the upgrade authority can initialize the relayer"
+    },
+    {
+      "code": 12001,
+      "name": "IncorrectRelayerProgram",
+      "msg": "Incorrect relayer program"
+    },
+    {
+      "code": 12100,
+      "name": "UnauthorizedConfigUpdate",
+      "msg": "Unauthorized to update configuration"
+    },
+    {
+      "code": 12200,
       "name": "GasLimitTooLow",
       "msg": "Gas limit too low"
     },
     {
-      "code": 6001,
+      "code": 12201,
       "name": "GasLimitExceeded",
       "msg": "Gas limit exceeded"
+    },
+    {
+      "code": 12300,
+      "name": "IncorrectGasFeeReceiver",
+      "msg": "Incorrect gas fee receiver"
     }
   ],
   "types": [

--- a/solana/programs/base_relayer/src/instructions/initialize.rs
+++ b/solana/programs/base_relayer/src/instructions/initialize.rs
@@ -120,7 +120,7 @@ mod tests {
             program_id: ID,
             accounts,
             data: instruction::Initialize {
-                new_guardian: guardian_pk,
+                guardian: guardian_pk,
                 eip1559_config: Eip1559Config::test_new(),
                 gas_config: GasConfig::test_new(gas_fee_receiver),
             }
@@ -184,7 +184,7 @@ mod tests {
             program_id: ID,
             accounts,
             data: instruction::Initialize {
-                new_guardian: guardian_pk,
+                guardian: guardian_pk,
                 eip1559_config: Eip1559Config::test_new(),
                 gas_config: GasConfig::test_new(gas_fee_receiver),
             }

--- a/solana/programs/base_relayer/src/lib.rs
+++ b/solana/programs/base_relayer/src/lib.rs
@@ -29,18 +29,19 @@ pub mod base_relayer {
     /// called once during deployment.
     ///
     /// # Arguments
-    /// * `ctx` - The context containing accounts for initialization: `payer` funds
-    ///           account creation, `cfg` PDA is created with seeds, and `guardian`
-    ///           is recorded as the admin authority.
-    /// * `cfg` - Initial configuration values: guardian pubkey, EIP-1559 state and
-    ///           config, and gas-cost configuration.
+    /// * `ctx`            - The context containing accounts for initialization: `payer` funds
+    ///                      account creation, `cfg` PDA is created with seeds, and `guardian`
+    ///                      is recorded as the admin authority.
+    /// * `guardian`       - The guardian address authorized to update configuration.
+    /// * `eip1559_config` - The EIP-1559 configuration.
+    /// * `gas_config`     - The gas configuration.
     pub fn initialize(
         ctx: Context<Initialize>,
-        new_guardian: Pubkey,
+        guardian: Pubkey,
         eip1559_config: Eip1559Config,
         gas_config: GasConfig,
     ) -> Result<()> {
-        initialize_handler(ctx, new_guardian, eip1559_config, gas_config)
+        initialize_handler(ctx, guardian, eip1559_config, gas_config)
     }
 
     /// Updates the EIP1559 configuration.

--- a/solana/programs/base_relayer/src/test_utils/mod.rs
+++ b/solana/programs/base_relayer/src/test_utils/mod.rs
@@ -186,7 +186,7 @@ pub fn setup_relayer() -> SetupRelayerResult {
         program_id: ID,
         accounts,
         data: Initialize {
-            new_guardian: guardian_pk,
+            guardian: guardian_pk,
             eip1559_config: Eip1559Config::test_new(),
             gas_config: GasConfig::test_new(TEST_GAS_FEE_RECEIVER),
         }

--- a/solana/programs/bridge/idl.json
+++ b/solana/programs/bridge/idl.json
@@ -1302,8 +1302,9 @@
         "This function sets up the initial bridge configuration and must be called once during deployment.",
         "",
         "# Arguments",
-        "* `ctx` - The context containing all accounts needed for initialization, including the guardian signer",
-        "* `cfg` - All the configuration parameters needed to initialize the bridge"
+        "* `ctx`      - The context containing all accounts needed for initialization, including the guardian signer",
+        "* `guardian` - The guardian account that will have administrative authority over the bridge",
+        "* `cfg`      - All the configuration parameters needed to initialize the bridge"
       ],
       "discriminator": [
         175,
@@ -1317,10 +1318,19 @@
       ],
       "accounts": [
         {
+          "name": "upgrade_authority",
+          "docs": [
+            "The upgrade authority that is authorized to initialize the bridge.",
+            "This ensures only the program deployer can set the initial configuration."
+          ],
+          "signer": true
+        },
+        {
           "name": "payer",
           "docs": [
             "The account that pays for the transaction and bridge account creation.",
-            "Must be mutable to deduct lamports for account rent."
+            "Must be mutable to deduct lamports for account rent.",
+            "Can be different from the upgrade_authority."
           ],
           "writable": true,
           "signer": true
@@ -1336,13 +1346,18 @@
           "writable": true
         },
         {
-          "name": "guardian",
+          "name": "program_data",
           "docs": [
-            "The guardian account that will have administrative authority over the bridge.",
-            "Must be a signer to prove ownership of the guardian key. The payer and guardian",
-            "may be distinct signers."
-          ],
-          "signer": true
+            "Program data account containing the upgrade authority.",
+            "Validates that the signer is indeed the upgrade authority."
+          ]
+        },
+        {
+          "name": "program",
+          "docs": [
+            "The bridge program itself.",
+            "Validates that program_data is the correct ProgramData account for this program."
+          ]
         },
         {
           "name": "system_program",
@@ -1353,6 +1368,10 @@
         }
       ],
       "args": [
+        {
+          "name": "guardian",
+          "type": "pubkey"
+        },
         {
           "name": "cfg",
           "type": {
@@ -2271,6 +2290,13 @@
       ],
       "accounts": [
         {
+          "name": "upgrade_authority",
+          "docs": [
+            "The upgrade authority account"
+          ],
+          "signer": true
+        },
+        {
           "name": "bridge",
           "docs": [
             "The bridge account containing configuration"
@@ -2278,11 +2304,10 @@
           "writable": true
         },
         {
-          "name": "guardian",
-          "docs": [
-            "The guardian account authorized to update configuration"
-          ],
-          "signer": true
+          "name": "program_data"
+        },
+        {
+          "name": "program"
         }
       ],
       "args": [
@@ -2317,6 +2342,13 @@
       ],
       "accounts": [
         {
+          "name": "upgrade_authority",
+          "docs": [
+            "The upgrade authority account"
+          ],
+          "signer": true
+        },
+        {
           "name": "bridge",
           "docs": [
             "The bridge account containing configuration"
@@ -2324,11 +2356,10 @@
           "writable": true
         },
         {
-          "name": "guardian",
-          "docs": [
-            "The guardian account authorized to update configuration"
-          ],
-          "signer": true
+          "name": "program_data"
+        },
+        {
+          "name": "program"
         }
       ],
       "args": [
@@ -2662,14 +2693,224 @@
   ],
   "errors": [
     {
-      "code": 6000,
-      "name": "MaxSizeExceeded",
+      "code": 12000,
+      "name": "BridgePaused",
+      "msg": "Bridge is currently paused"
+    },
+    {
+      "code": 12001,
+      "name": "IncorrectBridgeProgram",
+      "msg": "Incorrect bridge program"
+    },
+    {
+      "code": 12002,
+      "name": "IncorrectGasFeeReceiver",
+      "msg": "Incorrect gas fee receiver"
+    },
+    {
+      "code": 12100,
+      "name": "UnauthorizedInitialization",
+      "msg": "Only the upgrade authority can initialize the bridge"
+    },
+    {
+      "code": 12101,
+      "name": "UnauthorizedConfigUpdate",
+      "msg": "Unauthorized to update configuration"
+    },
+    {
+      "code": 12200,
+      "name": "BufferUnauthorizedClose",
+      "msg": "Only the owner can close this buffer"
+    },
+    {
+      "code": 12201,
+      "name": "BufferUnauthorizedAppend",
+      "msg": "Only the owner can append to this buffer"
+    },
+    {
+      "code": 12202,
+      "name": "BufferMaxSizeExceeded",
       "msg": "Call buffer size exceeds maximum allowed size"
     },
     {
-      "code": 6001,
-      "name": "InvalidBufferSize",
-      "msg": "Invalid buffer size provided"
+      "code": 12300,
+      "name": "InvalidRecoveryId",
+      "msg": "Invalid recovery ID"
+    },
+    {
+      "code": 12301,
+      "name": "SignatureVerificationFailed",
+      "msg": "Signature verification failed"
+    },
+    {
+      "code": 12302,
+      "name": "InsufficientBaseSignatures",
+      "msg": "Insufficient base oracle signatures to meet threshold"
+    },
+    {
+      "code": 12303,
+      "name": "InsufficientPartnerSignatures",
+      "msg": "Insufficient partner oracle signatures to meet threshold"
+    },
+    {
+      "code": 12400,
+      "name": "InvalidProof",
+      "msg": "Invalid proof"
+    },
+    {
+      "code": 12401,
+      "name": "MmrShouldBeEmpty",
+      "msg": "MMR should be empty"
+    },
+    {
+      "code": 12402,
+      "name": "EmptyMmr",
+      "msg": "MMR is empty"
+    },
+    {
+      "code": 12403,
+      "name": "LeafMountainNotFound",
+      "msg": "Leaf's mountain not found"
+    },
+    {
+      "code": 12404,
+      "name": "InsufficientProofElementsForIntraMountainPath",
+      "msg": "Insufficient proof elements for intra-mountain path"
+    },
+    {
+      "code": 12405,
+      "name": "InsufficientProofElementsForOtherMountainPeaks",
+      "msg": "Insufficient proof elements for other mountain peaks"
+    },
+    {
+      "code": 12406,
+      "name": "UnusedProofElementsRemaining",
+      "msg": "Unused proof elements remaining"
+    },
+    {
+      "code": 12407,
+      "name": "NoPeaksFoundForNonEmptyMmr",
+      "msg": "No peaks found for non-empty MMR"
+    },
+    {
+      "code": 12500,
+      "name": "InvalidMessageHash",
+      "msg": "Invalid message hash"
+    },
+    {
+      "code": 12501,
+      "name": "AlreadyExecuted",
+      "msg": "Message already executed"
+    },
+    {
+      "code": 12502,
+      "name": "IncorrectBlockNumber",
+      "msg": "Incorrect block number"
+    },
+    {
+      "code": 12600,
+      "name": "MintDoesNotMatchLocalToken",
+      "msg": "Mint does not match local token"
+    },
+    {
+      "code": 12601,
+      "name": "TokenAccountDoesNotMatchTo",
+      "msg": "Token account does not match to address"
+    },
+    {
+      "code": 12602,
+      "name": "IncorrectTokenVault",
+      "msg": "Incorrect token vault"
+    },
+    {
+      "code": 12603,
+      "name": "MintIsWrappedToken",
+      "msg": "Mint is a wrapped token"
+    },
+    {
+      "code": 12604,
+      "name": "IncorrectTo",
+      "msg": "Incorrect to"
+    },
+    {
+      "code": 12605,
+      "name": "IncorrectSolVault",
+      "msg": "Incorrect sol vault"
+    },
+    {
+      "code": 12700,
+      "name": "RemoteTokenNotFound",
+      "msg": "Remote token not found"
+    },
+    {
+      "code": 12701,
+      "name": "ScalerExponentNotFound",
+      "msg": "Scaler exponent not found"
+    },
+    {
+      "code": 12702,
+      "name": "InvalidRemoteToken",
+      "msg": "Invalid remote token"
+    },
+    {
+      "code": 12703,
+      "name": "InvalidScalerExponent",
+      "msg": "Invalid scaler exponent"
+    },
+    {
+      "code": 12704,
+      "name": "MintIsNotFromToken2022",
+      "msg": "Mint is not a token 2022 mint"
+    },
+    {
+      "code": 12705,
+      "name": "MintIsNotWrappedTokenPda",
+      "msg": "Mint is not a valid wrapped token PDA"
+    },
+    {
+      "code": 12800,
+      "name": "InvalidThreshold",
+      "msg": "Threshold must be <= number of signers"
+    },
+    {
+      "code": 12801,
+      "name": "TooManySigners",
+      "msg": "Too many signers (max 32)"
+    },
+    {
+      "code": 12802,
+      "name": "DuplicateSigner",
+      "msg": "Duplicate signer found"
+    },
+    {
+      "code": 12803,
+      "name": "InvalidPartnerThreshold",
+      "msg": "Invalid partner threshold"
+    },
+    {
+      "code": 12804,
+      "name": "InvalidDenominator",
+      "msg": "Invalid denominator"
+    },
+    {
+      "code": 12805,
+      "name": "InvalidWindowDurationSeconds",
+      "msg": "Invalid window duration seconds"
+    },
+    {
+      "code": 12806,
+      "name": "InvalidGasCostScalerDp",
+      "msg": "Invalid gas cost scaler dp"
+    },
+    {
+      "code": 12807,
+      "name": "InvalidBlockIntervalRequirement",
+      "msg": "Invalid block interval requirement"
+    },
+    {
+      "code": 12900,
+      "name": "CreationWithNonZeroTarget",
+      "msg": "Creation with non-zero target"
     }
   ],
   "types": [


### PR DESCRIPTION
- Rename `new_guardian` to `guardian` in base-relayer's initialize instruction
- Regenerate the typescript clients for both programs
- Fix the initialize commands in the script