### PR TITLE
fix: include missing assumtion to exclude native sol

### DIFF
--- a/base/test/CrossChainERC20Factory.t.sol
+++ b/base/test/CrossChainERC20Factory.t.sol
@@ -210,7 +210,7 @@ contract CrossChainERC20FactoryTest is CommonTest {
         string memory symbol,
         uint8 decimals
     ) public {
-        vm.assume(remoteToken != bytes32(0) && remoteToken != factory.SOL_PUBKEY());
+        vm.assume(remoteToken != bytes32(0) && remoteToken != Pubkey.unwrap(TokenLib.NATIVE_SOL_PUBKEY));
 
         // Generate 2 random deployer addresses.
         address randomDeployer1 = makeAddr(string.concat("deployer1", vm.toString(remoteToken)));


### PR DESCRIPTION
gm. while running the tests, I noticed one of the fuzzy tests was failing. following the previous test, I added an extra assumption to skip it for native SOL on Base