### PR TITLE
feat: improve error condition

### DIFF
--- a/base/src/Bridge.sol
+++ b/base/src/Bridge.sol
@@ -175,8 +175,9 @@ contract Bridge is ReentrancyGuardTransient, Initializable, OwnableRoles {
 
     /// @notice Bridges a transfer with an optional list of instructions to the Solana bridge.
     ///
-    /// @dev If `localToken` is a wrapped version of a Solana asset, `remoteToken` must be unset.
-    ///      The bridge will fill in `remoteToken` automatically
+    /// @dev If `localToken` is a wrapped version of a Solana asset, `remoteToken` is an optional arg.
+    ///      If the received `remoteToken` is bytes32(0), the bridge will override it with the correct value
+    ///      automatically
     ///
     /// @param transfer The token transfer to execute.
     /// @param ixs      The optional Solana instructions.

--- a/base/src/libraries/TokenLib.sol
+++ b/base/src/libraries/TokenLib.sol
@@ -145,10 +145,14 @@ library TokenLib {
 
             if (CrossChainERC20Factory(crossChainErc20Factory).isCrossChainErc20(transfer.localToken)) {
                 // Case: Bridging back native SOL or SPL token to Solana
-                require(Pubkey.unwrap(transfer.remoteToken) == bytes32(0), IncorrectRemoteToken());
+                Pubkey expectedRemoteToken = Pubkey.wrap(CrossChainERC20(transfer.localToken).remoteToken());
+                require(
+                    Pubkey.unwrap(transfer.remoteToken) == bytes32(0) || transfer.remoteToken == expectedRemoteToken,
+                    IncorrectRemoteToken()
+                );
 
                 // IMPORTANT: Update the transfer struct IN MEMORY to reflect the remote token to use for bridging.
-                transfer.remoteToken = Pubkey.wrap(CrossChainERC20(transfer.localToken).remoteToken());
+                transfer.remoteToken = expectedRemoteToken;
 
                 localAmount = transfer.remoteAmount;
                 CrossChainERC20(transfer.localToken).burn({from: msg.sender, amount: localAmount});


### PR DESCRIPTION
When bridging a Solana asset back to Solana, we were previously reverting if `remoteToken` was not set to `bytes32(0)`. This is because the bridge overrides the value with what is stored in storage for `localToken`. This PR relaxes that error condition to only revert if `remoteToken` is not `bytes32(0)` and is also not the correct expected value