### PR TITLE
fix: guardian update authorization

### DIFF
--- a/solana/programs/bridge/src/common/instructions/guardian.rs
+++ b/solana/programs/bridge/src/common/instructions/guardian.rs
@@ -10,9 +10,23 @@ pub fn transfer_guardian_handler(
     ctx: Context<SetBridgeConfigFromGuardian>,
     new_guardian: Pubkey,
 ) -> Result<()> {
+    let bridge = &mut ctx.accounts.bridge;
+    let guardian_account = &ctx.accounts.guardian;
+
+    require_keys_eq!(
+        bridge.guardian,
+        guardian_account.key(),
+        BridgeError::UnauthorizedConfigUpdate
+    );
+
     ctx.accounts.bridge.guardian = new_guardian;
 
     Ok(())
+}
+
+#[error_code]
+pub enum BridgeError {
+    UnauthorizedConfigUpdate,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
added a missing authorization check inside `transfer_guardian_handler` to ensure only the current guardian can update the `bridge.guardian` field:

```rust
require_keys_eq!(bridge.guardian, guardian_account.key(), BridgeError::UnauthorizedConfigUpdate);
```

without this check, any account could potentially replace the guardian.

I also introduced the `BridgeError` enum with a new `UnauthorizedConfigUpdate` variant (annotated with `#[error_code]`), so the handler now returns a clear, expected error when the update is unauthorized.

this restores the intended behavior - guardian changes now succeed only when signed by the existing guardian and fail with `UnauthorizedConfigUpdate` otherwise.
