### PR TITLE
Harden validator signatures, token route safety, and Solana gas/signer guards

### DIFF
--- a/base/src/BridgeValidator.sol
+++ b/base/src/BridgeValidator.sol
@@ -45,12 +45,18 @@ contract BridgeValidator is Initializable {
     /// @notice A bit to be used in bitshift operations
     uint256 private constant _BIT = 1;
 
+    /// @notice Domain separator for validator signatures.
+    bytes32 private constant _SIGNATURE_DOMAIN_SEPARATOR = keccak256("BASE_BRIDGE_VALIDATOR_V2");
+
     //////////////////////////////////////////////////////////////
     ///                       Storage                          ///
     //////////////////////////////////////////////////////////////
 
     /// @notice Required number of partner signatures
     uint256 public partnerValidatorThreshold;
+
+    /// @notice Compatibility switch for legacy signatures on `abi.encode(messageHashes)`.
+    bool public legacySignatureValidationEnabled;
 
     /// @notice The next expected nonce to be received in `registerMessages`
     uint256 public nextNonce;
@@ -75,6 +81,9 @@ contract BridgeValidator is Initializable {
     /// @param oldThreshold The previous partner validator threshold.
     /// @param newThreshold The new partner validator threshold.
     event PartnerThresholdUpdated(uint256 oldThreshold, uint256 newThreshold);
+
+    /// @notice Emitted when legacy signature validation support is toggled.
+    event LegacySignatureValidationStatusUpdated(bool enabled);
 
     //////////////////////////////////////////////////////////////
     ///                       Errors                           ///
@@ -104,6 +113,9 @@ contract BridgeValidator is Initializable {
     /// @notice Thrown when the recovered signers are not sorted
     error UnsortedSigners();
 
+    /// @notice Thrown when a signer is configured in both Base and partner signer sets.
+    error OverlappingSignerSets();
+
     /// @notice Thrown when attempting to register an empty batch of messages
     error NoMessages();
 
@@ -117,6 +129,12 @@ contract BridgeValidator is Initializable {
     /// @dev Restricts function to when the Bridge is not paused
     modifier whenNotPaused() {
         require(!Bridge(BRIDGE).paused(), Paused());
+        _;
+    }
+
+    /// @dev Restricts function calls to guardians from the Bridge contract.
+    modifier onlyGuardian() {
+        require(Bridge(BRIDGE).hasAnyRole(msg.sender, GUARDIAN_ROLE), CallerNotGuardian());
         _;
     }
 
@@ -135,6 +153,7 @@ contract BridgeValidator is Initializable {
         require(partnerValidators != address(0), ZeroAddress());
 
         partnerValidatorThreshold = type(uint256).max;
+        legacySignatureValidationEnabled = true;
         VerificationLib.getVerificationLibStorage().threshold = type(uint128).max;
 
         BRIDGE = bridgeAddress;
@@ -157,6 +176,7 @@ contract BridgeValidator is Initializable {
 
         require(partnerThreshold <= MAX_PARTNER_VALIDATOR_THRESHOLD, ThresholdTooHigh());
         partnerValidatorThreshold = partnerThreshold;
+        legacySignatureValidationEnabled = true;
     }
 
     /// @notice Pre-validates a batch of Solana → Base messages.
@@ -212,6 +232,17 @@ contract BridgeValidator is Initializable {
         return VerificationLib.isBaseValidator(validator);
     }
 
+    /// @notice Returns the domain-aware signable digest for a batch of message hashes.
+    function getSignableHash(bytes32[] memory messageHashes) external view returns (bytes32) {
+        return _getDomainAwareSignableHash(messageHashes);
+    }
+
+    /// @notice Enables or disables legacy signature validation.
+    function setLegacySignatureValidationEnabled(bool enabled) external onlyGuardian {
+        legacySignatureValidationEnabled = enabled;
+        emit LegacySignatureValidationStatusUpdated(enabled);
+    }
+
     //////////////////////////////////////////////////////////////
     ///                    Private Functions                   ///
     //////////////////////////////////////////////////////////////
@@ -221,30 +252,24 @@ contract BridgeValidator is Initializable {
     /// @param messageHashes The derived message hashes (inner hash + nonce) for the batch.
     /// @param sigData       Concatenated signatures over `toEthSignedMessageHash(abi.encode(messageHashes))`.
     function _validateSigs(bytes32[] memory messageHashes, bytes calldata sigData) private view {
-        address[] memory recoveredSigners = _getSignersFromSigs(messageHashes, sigData);
-        require(_countBaseSigners(recoveredSigners) >= VerificationLib.getBaseThreshold(), BaseThresholdNotMet());
-
-        uint256 partnerValidatorThreshold_ = partnerValidatorThreshold;
-        if (partnerValidatorThreshold_ > 0) {
-            IPartner.Signer[] memory partnerValidators = IPartner(PARTNER_VALIDATORS).getSigners();
-            require(
-                _countPartnerSigners(partnerValidators, recoveredSigners) >= partnerValidatorThreshold_,
-                PartnerThresholdNotMet()
-            );
-        }
-    }
-
-    function _getSignersFromSigs(bytes32[] memory messageHashes, bytes calldata sigData)
-        private
-        view
-        returns (address[] memory)
-    {
-        // Check that the provided signature data is a multiple of the valid sig length
         require(sigData.length % VerificationLib.SIGNATURE_LENGTH_THRESHOLD == 0, InvalidSignatureLength());
 
+        // Primary verification path: domain-bound signatures.
+        if (_isSignatureSetValid(_getDomainAwareSignableHash(messageHashes), sigData)) {
+            return;
+        }
+
+        // Backward-compatible fallback for old offchain signers.
+        if (legacySignatureValidationEnabled && _isSignatureSetValid(_getLegacySignableHash(messageHashes), sigData)) {
+            return;
+        }
+
+        // Re-run strict checks on the primary digest so callers get specific errors.
+        _assertSignatureSetValid(_getDomainAwareSignableHash(messageHashes), sigData);
+    }
+
+    function _getSignersFromSigs(bytes32 signedHash, bytes calldata sigData) private view returns (address[] memory) {
         uint256 sigCount = sigData.length / VerificationLib.SIGNATURE_LENGTH_THRESHOLD;
-        bytes32 signedHash = ECDSA.toEthSignedMessageHash(abi.encode(messageHashes));
-        address lastValidator = address(0);
         address[] memory recoveredSigners = new address[](sigCount);
 
         uint256 offset;
@@ -255,12 +280,52 @@ contract BridgeValidator is Initializable {
         for (uint256 i; i < sigCount; i++) {
             (uint8 v, bytes32 r, bytes32 s) = VerificationLib.signatureSplit(offset, i);
             address currentValidator = signedHash.recover(v, r, s);
-            require(currentValidator > lastValidator, UnsortedSigners());
             recoveredSigners[i] = currentValidator;
-            lastValidator = currentValidator;
         }
 
         return recoveredSigners;
+    }
+
+    function _assertSignatureSetValid(bytes32 signedHash, bytes calldata sigData) private view {
+        address[] memory recoveredSigners = _getSignersFromSigs(signedHash, sigData);
+        _assertSortedSigners(recoveredSigners);
+        require(_countBaseSigners(recoveredSigners) >= VerificationLib.getBaseThreshold(), BaseThresholdNotMet());
+
+        uint256 partnerValidatorThreshold_ = partnerValidatorThreshold;
+        if (partnerValidatorThreshold_ > 0) {
+            IPartner.Signer[] memory partnerValidators = IPartner(PARTNER_VALIDATORS).getSigners();
+            if (_hasSignerSetOverlap(partnerValidators, recoveredSigners)) {
+                revert OverlappingSignerSets();
+            }
+            require(
+                _countPartnerSigners(partnerValidators, recoveredSigners) >= partnerValidatorThreshold_,
+                PartnerThresholdNotMet()
+            );
+        }
+    }
+
+    function _isSignatureSetValid(bytes32 signedHash, bytes calldata sigData) private view returns (bool) {
+        address[] memory recoveredSigners = _getSignersFromSigs(signedHash, sigData);
+        if (!_areSignersStrictlySorted(recoveredSigners)) {
+            return false;
+        }
+        if (_countBaseSigners(recoveredSigners) < VerificationLib.getBaseThreshold()) {
+            return false;
+        }
+
+        uint256 partnerValidatorThreshold_ = partnerValidatorThreshold;
+        if (partnerValidatorThreshold_ == 0) {
+            return true;
+        }
+
+        IPartner.Signer[] memory partnerValidators = IPartner(PARTNER_VALIDATORS).getSigners();
+        if (_hasSignerSetOverlap(partnerValidators, recoveredSigners)) {
+            return false;
+        }
+
+        (uint256 partnerSignerCount, bool validPartnerBitmap) =
+            _countPartnerSignersIfValid(partnerValidators, recoveredSigners);
+        return validPartnerBitmap && partnerSignerCount >= partnerValidatorThreshold_;
     }
 
     function _countBaseSigners(address[] memory signers) private view returns (uint256) {
@@ -282,7 +347,18 @@ contract BridgeValidator is Initializable {
         pure
         returns (uint256)
     {
-        uint256 count;
+        (uint256 count, bool validPartnerBitmap) = _countPartnerSignersIfValid(partnerValidators, signers);
+        if (!validPartnerBitmap) {
+            revert DuplicateSigner();
+        }
+        return count;
+    }
+
+    function _countPartnerSignersIfValid(IPartner.Signer[] memory partnerValidators, address[] memory signers)
+        private
+        pure
+        returns (uint256 count, bool validPartnerBitmap)
+    {
         uint256 signedBitMap;
 
         for (uint256 i; i < signers.length; i++) {
@@ -292,7 +368,7 @@ contract BridgeValidator is Initializable {
             }
 
             if (signedBitMap & (_BIT << partnerIndex) != 0) {
-                revert DuplicateSigner();
+                return (0, false);
             }
 
             signedBitMap |= _BIT << partnerIndex;
@@ -301,7 +377,45 @@ contract BridgeValidator is Initializable {
             }
         }
 
-        return count;
+        return (count, true);
+    }
+
+    function _assertSortedSigners(address[] memory signers) private pure {
+        require(_areSignersStrictlySorted(signers), UnsortedSigners());
+    }
+
+    function _areSignersStrictlySorted(address[] memory signers) private pure returns (bool) {
+        address lastSigner = address(0);
+        for (uint256 i; i < signers.length; i++) {
+            if (signers[i] <= lastSigner) {
+                return false;
+            }
+            lastSigner = signers[i];
+        }
+        return true;
+    }
+
+    function _hasSignerSetOverlap(IPartner.Signer[] memory partnerValidators, address[] memory signers)
+        private
+        view
+        returns (bool)
+    {
+        for (uint256 i; i < signers.length; i++) {
+            if (VerificationLib.isBaseValidator(signers[i]) && _indexOf(partnerValidators, signers[i]) != partnerValidators.length) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    function _getDomainAwareSignableHash(bytes32[] memory messageHashes) private view returns (bytes32) {
+        return ECDSA.toEthSignedMessageHash(
+            abi.encode(_SIGNATURE_DOMAIN_SEPARATOR, block.chainid, address(this), messageHashes)
+        );
+    }
+
+    function _getLegacySignableHash(bytes32[] memory messageHashes) private pure returns (bytes32) {
+        return ECDSA.toEthSignedMessageHash(abi.encode(messageHashes));
     }
 
     /// @dev Linear search for `addr` in memory array `addrs`.

--- a/base/src/libraries/TokenLib.sol
+++ b/base/src/libraries/TokenLib.sol
@@ -39,6 +39,7 @@ enum SolanaTokenType {
 struct TokenLibStorage {
     mapping(address localToken => mapping(Pubkey remoteToken => uint256 amount)) deposits;
     mapping(address localToken => mapping(Pubkey remoteToken => uint256 scalar)) scalars;
+    mapping(Pubkey remoteToken => address localToken) canonicalLocalByRemoteToken;
 }
 
 library TokenLib {
@@ -61,6 +62,15 @@ library TokenLib {
     /// @notice Thrown when cumulative deposits exceed uint64 max when scaled to remote amount.
     error CumulativeDepositExceedsU64();
 
+    /// @notice Thrown when scalar exponent would overflow `10 ** scalarExponent`.
+    error InvalidScalarExponent();
+
+    /// @notice Thrown when a remote token is already mapped to a different local token.
+    error RemoteTokenAlreadyMapped();
+
+    /// @notice Thrown when an existing route is re-registered with a different scalar.
+    error RouteScalarMismatch();
+
     //////////////////////////////////////////////////////////////
     ///                       Events                           ///
     //////////////////////////////////////////////////////////////
@@ -80,6 +90,9 @@ library TokenLib {
     /// @param to Address of the recipient on Base.
     /// @param amount Amount of tokens bridged to the recipient (expressed in local units).
     event TransferFinalized(address localToken, Pubkey remoteToken, address to, uint256 amount);
+
+    /// @notice Emitted when a new remote token route scalar is registered.
+    event RemoteTokenRouteRegistered(address localToken, Pubkey remoteToken, uint256 scalar);
 
     //////////////////////////////////////////////////////////////
     ///                       Constants                        ///
@@ -268,7 +281,24 @@ library TokenLib {
     ///        (localAmount = remoteAmount * 10^scalarExponent).
     function registerRemoteToken(address localToken, Pubkey remoteToken, uint8 scalarExponent) internal {
         TokenLibStorage storage $ = getTokenLibStorage();
-        $.scalars[localToken][remoteToken] = 10 ** scalarExponent;
+        require(scalarExponent <= 77, InvalidScalarExponent());
+        uint256 scalar = 10 ** scalarExponent;
+
+        address canonicalLocal = $.canonicalLocalByRemoteToken[remoteToken];
+        if (canonicalLocal == address(0)) {
+            $.canonicalLocalByRemoteToken[remoteToken] = localToken;
+        } else {
+            require(canonicalLocal == localToken, RemoteTokenAlreadyMapped());
+        }
+
+        uint256 existingScalar = $.scalars[localToken][remoteToken];
+        if (existingScalar == 0) {
+            $.scalars[localToken][remoteToken] = scalar;
+            emit RemoteTokenRouteRegistered(localToken, remoteToken, scalar);
+            return;
+        }
+
+        require(existingScalar == scalar, RouteScalarMismatch());
     }
 
     //////////////////////////////////////////////////////////////

--- a/base/test/Bridge.t.sol
+++ b/base/test/Bridge.t.sol
@@ -1096,12 +1096,12 @@ contract BridgeTest is CommonTest {
             "Scalars for unregistered token pair should be 0"
         );
 
-        // Test updating scalar by re-registering
+        // Re-registration with a different exponent must not mutate an existing route scalar.
         _registerTokenPair(address(mockToken), TEST_REMOTE_TOKEN, 6, 4);
         assertEq(
             bridge.scalars(address(mockToken), TEST_REMOTE_TOKEN),
-            1e6,
-            "Scalar should be updated when re-registering token pair"
+            1e12,
+            "Scalar should remain unchanged for conflicting re-registration"
         );
 
         // Test large scalar exponent

--- a/base/test/BridgeValidator.t.sol
+++ b/base/test/BridgeValidator.t.sol
@@ -29,6 +29,7 @@ contract BridgeValidatorTest is CommonTest {
     event ValidatorAdded(address validator);
     event ValidatorRemoved(address validator);
     event PartnerThresholdUpdated(uint256 oldThreshold, uint256 newThreshold);
+    event LegacySignatureValidationStatusUpdated(bool enabled);
 
     function setUp() public {
         DeployScript deployer = new DeployScript();
@@ -199,10 +200,10 @@ contract BridgeValidatorTest is CommonTest {
 
         // Calculate message hash
         bytes32[] memory finalHashes = _calculateFinalHashes(signedMessages);
-        bytes memory signedHash = abi.encode(finalHashes);
+        bytes32 signedDigest = bridgeValidator.getSignableHash(finalHashes);
 
         // Only oracle signature -> should fail ThresholdNotMet
-        bytes memory oracleSig = _createSignature(signedHash, 77);
+        bytes memory oracleSig = _createDigestSignature(signedDigest, 77);
         vm.expectRevert(BridgeValidator.PartnerThresholdNotMet.selector);
         vm.prank(testOracle);
         bridgeValidator.registerMessages(signedMessages, oracleSig);
@@ -240,11 +241,11 @@ contract BridgeValidatorTest is CommonTest {
         });
 
         bytes32[] memory finalHashes = _calculateFinalHashes(signedMessages);
-        bytes memory signedHash = abi.encode(finalHashes);
+        bytes32 signedDigest = bridgeValidator.getSignableHash(finalHashes);
 
         // Create duplicate signatures from same signer
-        bytes memory sig1 = _createSignature(signedHash, 1);
-        bytes memory sig2 = _createSignature(signedHash, 1);
+        bytes memory sig1 = _createDigestSignature(signedDigest, 1);
+        bytes memory sig2 = _createDigestSignature(signedDigest, 1);
         bytes memory duplicateSigs = abi.encodePacked(sig1, sig2);
 
         vm.expectRevert(BridgeValidator.UnsortedSigners.selector);
@@ -258,7 +259,7 @@ contract BridgeValidatorTest is CommonTest {
         });
 
         bytes32[] memory finalHashes = _calculateFinalHashes(signedMessages);
-        bytes memory signedHash = abi.encode(finalHashes);
+        bytes32 signedDigest = bridgeValidator.getSignableHash(finalHashes);
 
         // Create signatures in wrong order (addresses should be sorted)
         uint256 key1 = 1;
@@ -273,8 +274,8 @@ contract BridgeValidatorTest is CommonTest {
         }
 
         // Now create signatures in reverse order
-        bytes memory sig1 = _createSignature(signedHash, key2); // Higher address first
-        bytes memory sig2 = _createSignature(signedHash, key1); // Lower address second
+        bytes memory sig1 = _createDigestSignature(signedDigest, key2); // Higher address first
+        bytes memory sig2 = _createDigestSignature(signedDigest, key1); // Lower address second
         bytes memory unsortedSigs = abi.encodePacked(sig1, sig2);
 
         vm.expectRevert(BridgeValidator.UnsortedSigners.selector);
@@ -296,13 +297,13 @@ contract BridgeValidatorTest is CommonTest {
             outgoingMessagePubkey: TEST_OUTGOING_MESSAGE, innerMessageHash: TEST_MESSAGE_HASH_1
         });
         bytes32[] memory finalHashes = _calculateFinalHashes(signedMessages);
-        bytes memory signedHash = abi.encode(finalHashes);
+        bytes32 signedDigest = bridgeValidator.getSignableHash(finalHashes);
 
         // Create signatures from: base validator and both partner keys
         address baseAddr = vm.addr(1);
-        bytes memory sigBase = _createSignature(signedHash, 1);
-        bytes memory sigP1 = _createSignature(signedHash, 100);
-        bytes memory sigP2 = _createSignature(signedHash, 101);
+        bytes memory sigBase = _createDigestSignature(signedDigest, 1);
+        bytes memory sigP1 = _createDigestSignature(signedDigest, 100);
+        bytes memory sigP2 = _createDigestSignature(signedDigest, 101);
 
         // Concatenate in strictly ascending address order to satisfy UnsortedSigners check
         address a0 = baseAddr;
@@ -351,10 +352,10 @@ contract BridgeValidatorTest is CommonTest {
 
         // Calculate final hashes with the validator's current nonce
         bytes32[] memory finalHashes = _calculateFinalHashes(signedMessages);
-        bytes memory signedHash = abi.encode(finalHashes);
+        bytes32 signedDigest = bridgeValidator.getSignableHash(finalHashes);
 
         // Only BASE_ORACLE signature should fail threshold check
-        bytes memory oracleSig = _createSignature(signedHash, 100);
+        bytes memory oracleSig = _createDigestSignature(signedDigest, 100);
 
         vm.expectRevert(BridgeValidator.PartnerThresholdNotMet.selector);
         vm.prank(testOracle);
@@ -378,12 +379,12 @@ contract BridgeValidatorTest is CommonTest {
 
         // Compute final hash using the proxy's current nonce
         bytes32[] memory finalHashes = _calculateFinalHashes(signedMessages);
-        bytes memory signedHash = abi.encode(finalHashes);
+        bytes32 signedDigest = bridgeValidator.getSignableHash(finalHashes);
 
         // Create Base and partner signatures and order them by ascending signer address
         address baseAddr = vm.addr(1);
-        bytes memory sigBase = _createSignature(signedHash, 1);
-        bytes memory sigPartner = _createSignature(signedHash, 100);
+        bytes memory sigBase = _createDigestSignature(signedDigest, 1);
+        bytes memory sigPartner = _createDigestSignature(signedDigest, 100);
         bytes memory orderedSigs =
             baseAddr < partnerAddr ? abi.encodePacked(sigBase, sigPartner) : abi.encodePacked(sigPartner, sigBase);
 
@@ -392,6 +393,51 @@ contract BridgeValidatorTest is CommonTest {
 
         // Verify the message is registered
         assertTrue(bridgeValidator.validMessages(finalHashes[0]));
+    }
+
+    function test_registerMessages_revertsWhenBaseAndPartnerSetsOverlap() public {
+        _mockPartnerThreshold(1);
+        MockPartnerValidators(cfg.partnerValidators).addSigner(
+            IPartner.Signer({evmAddress: vm.addr(1), newEvmAddress: address(0)})
+        );
+
+        BridgeValidator.SignedMessage[] memory signedMessages = new BridgeValidator.SignedMessage[](1);
+        signedMessages[0] = BridgeValidator.SignedMessage({
+            outgoingMessagePubkey: TEST_OUTGOING_MESSAGE, innerMessageHash: TEST_MESSAGE_HASH_1
+        });
+
+        bytes memory sigs = _getValidatorSigs(signedMessages);
+        vm.expectRevert(BridgeValidator.OverlappingSignerSets.selector);
+        bridgeValidator.registerMessages(signedMessages, sigs);
+    }
+
+    function test_registerMessages_acceptsLegacySigsWhenCompatibilityEnabled() public {
+        BridgeValidator.SignedMessage[] memory signedMessages = new BridgeValidator.SignedMessage[](1);
+        signedMessages[0] = BridgeValidator.SignedMessage({
+            outgoingMessagePubkey: TEST_OUTGOING_MESSAGE, innerMessageHash: TEST_MESSAGE_HASH_1
+        });
+
+        bytes32[] memory finalHashes = _calculateFinalHashes(signedMessages);
+        bytes memory legacySigs = _createSignature(abi.encode(finalHashes), 1);
+
+        bridgeValidator.registerMessages(signedMessages, legacySigs);
+        assertTrue(bridgeValidator.validMessages(finalHashes[0]));
+    }
+
+    function test_registerMessages_rejectsLegacySigsAfterCompatibilityDisabled() public {
+        vm.prank(cfg.guardians[0]);
+        bridgeValidator.setLegacySignatureValidationEnabled(false);
+
+        BridgeValidator.SignedMessage[] memory signedMessages = new BridgeValidator.SignedMessage[](1);
+        signedMessages[0] = BridgeValidator.SignedMessage({
+            outgoingMessagePubkey: TEST_OUTGOING_MESSAGE, innerMessageHash: TEST_MESSAGE_HASH_1
+        });
+
+        bytes32[] memory finalHashes = _calculateFinalHashes(signedMessages);
+        bytes memory legacySigs = _createSignature(abi.encode(finalHashes), 1);
+
+        vm.expectRevert(BridgeValidator.BaseThresholdNotMet.selector);
+        bridgeValidator.registerMessages(signedMessages, legacySigs);
     }
 
     //////////////////////////////////////////////////////////////
@@ -422,6 +468,20 @@ contract BridgeValidatorTest is CommonTest {
     function test_initialize_revertsWhenCalledTwice() public {
         vm.expectRevert(Initializable.InvalidInitialization.selector);
         bridgeValidator.initialize(cfg.baseValidators, cfg.baseSignatureThreshold, cfg.partnerValidatorThreshold);
+    }
+
+    function test_setLegacySignatureValidationEnabled_revertsForNonGuardian() public {
+        vm.prank(address(0x1234));
+        vm.expectRevert(BridgeValidator.CallerNotGuardian.selector);
+        bridgeValidator.setLegacySignatureValidationEnabled(false);
+    }
+
+    function test_setLegacySignatureValidationEnabled_emitsEvent() public {
+        vm.expectEmit(false, false, false, true);
+        emit LegacySignatureValidationStatusUpdated(false);
+
+        vm.prank(cfg.guardians[0]);
+        bridgeValidator.setLegacySignatureValidationEnabled(false);
     }
 
     function test_nextNonce_incrementsByBatchLength() public {

--- a/base/test/CommonTest.t.sol
+++ b/base/test/CommonTest.t.sol
@@ -54,7 +54,12 @@ contract CommonTest is Test {
         returns (bytes memory)
     {
         bytes32[] memory messageHashes = _calculateFinalHashes(signedMessages);
-        return _createSignature(abi.encode(messageHashes), 1);
+        return _createDigestSignature(bridgeValidator.getSignableHash(messageHashes), 1);
+    }
+
+    function _createDigestSignature(bytes32 digest, uint256 privateKey) internal pure returns (bytes memory) {
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
+        return abi.encodePacked(r, s, v);
     }
 
     function _createSignature(bytes memory message, uint256 privateKey) internal pure returns (bytes memory) {

--- a/base/test/libraries/TokenLib.t.sol
+++ b/base/test/libraries/TokenLib.t.sol
@@ -95,6 +95,29 @@ contract TokenLibTest is CommonTest {
         }
     }
 
+    function test_registerRemoteToken_rejectsExponentOverflowsScalar() public {
+        _registerTokenPair(address(mockToken), TEST_REMOTE_TOKEN, 78, 0);
+        assertEq(bridge.scalars(address(mockToken), TEST_REMOTE_TOKEN), 0);
+    }
+
+    function test_registerRemoteToken_rejectsRemoteTokenRemapped() public {
+        address tokenA = makeAddr("tokenA");
+        address tokenB = makeAddr("tokenB");
+
+        _registerTokenPair(tokenA, TEST_REMOTE_TOKEN, 12, 0);
+        _registerTokenPair(tokenB, TEST_REMOTE_TOKEN, 12, 1);
+
+        assertEq(bridge.scalars(tokenA, TEST_REMOTE_TOKEN), 1e12);
+        assertEq(bridge.scalars(tokenB, TEST_REMOTE_TOKEN), 0);
+    }
+
+    function test_registerRemoteToken_isIdempotentForSameRoute() public {
+        _registerTokenPair(address(mockToken), TEST_REMOTE_TOKEN, 12, 0);
+        _registerTokenPair(address(mockToken), TEST_REMOTE_TOKEN, 12, 1);
+
+        assertEq(bridge.scalars(address(mockToken), TEST_REMOTE_TOKEN), 1e12);
+    }
+
     //////////////////////////////////////////////////////////////
     ///               Initialize Transfer Tests                ///
     //////////////////////////////////////////////////////////////

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -5,6 +5,7 @@
     "private": true,
     "scripts": {
         "cli": "bun run src/bin.ts",
+        "verify:program-identity": "bun run src/verifyProgramIdentity.ts",
         "postinstall": "cd ../clients/ts && bun install && bun run build"
     },
     "devDependencies": {

--- a/scripts/src/verifyProgramIdentity.ts
+++ b/scripts/src/verifyProgramIdentity.ts
@@ -1,0 +1,117 @@
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+type Identity = {
+  bridgeDeclareId: string;
+  relayerDeclareId: string;
+  constantsMainnetBridgeProgram: string;
+  constantsMainnetBaseRelayerProgram: string;
+  readmeMainnetBridgeProgram: string;
+  readmeMainnetBaseRelayerProgram: string;
+};
+
+function mustMatch(input: string, pattern: RegExp, label: string): string {
+  const match = input.match(pattern);
+  if (!match?.[1]) {
+    throw new Error(`Unable to parse ${label}`);
+  }
+  return match[1];
+}
+
+function loadIdentity(repoRoot: string): Identity {
+  const bridgeLib = readFileSync(
+    join(repoRoot, "solana/programs/bridge/src/lib.rs"),
+    "utf8"
+  );
+  const relayerLib = readFileSync(
+    join(repoRoot, "solana/programs/base_relayer/src/lib.rs"),
+    "utf8"
+  );
+  const constants = readFileSync(
+    join(repoRoot, "scripts/src/internal/constants.ts"),
+    "utf8"
+  );
+  const solanaReadme = readFileSync(join(repoRoot, "solana/README.md"), "utf8");
+
+  return {
+    bridgeDeclareId: mustMatch(
+      bridgeLib,
+      /declare_id!\("([^"]+)"\);/,
+      "bridge declare_id"
+    ),
+    relayerDeclareId: mustMatch(
+      relayerLib,
+      /declare_id!\("([^"]+)"\);/,
+      "base_relayer declare_id"
+    ),
+    constantsMainnetBridgeProgram: mustMatch(
+      constants,
+      /mainnet:[\s\S]*?bridgeProgram:\s*address\(\s*"([^"]+)"\s*\)/,
+      "constants mainnet bridgeProgram"
+    ),
+    constantsMainnetBaseRelayerProgram: mustMatch(
+      constants,
+      /mainnet:[\s\S]*?baseRelayerProgram:\s*address\(\s*"([^"]+)"\s*\)/,
+      "constants mainnet baseRelayerProgram"
+    ),
+    readmeMainnetBridgeProgram: mustMatch(
+      solanaReadme,
+      /\*\*Mainnet Bridge\*\*:\s*`([^`]+)`/,
+      "README mainnet bridge"
+    ),
+    readmeMainnetBaseRelayerProgram: mustMatch(
+      solanaReadme,
+      /\*\*Mainnet Base Relayer\*\*:\s*`([^`]+)`/,
+      "README mainnet base relayer"
+    ),
+  };
+}
+
+function compare(label: string, source: string, deployedRef: string): boolean {
+  if (source === deployedRef) {
+    console.log(`[OK] ${label}`);
+    return true;
+  }
+
+  console.error(
+    `[MISMATCH] ${label}\n  source: ${source}\n  deployed-ref: ${deployedRef}`
+  );
+  return false;
+}
+
+function run() {
+  const repoRoot = resolve(__dirname, "..", "..");
+  const identity = loadIdentity(repoRoot);
+
+  let ok = true;
+  ok =
+    compare(
+      "bridge source declare_id vs constants mainnet bridgeProgram",
+      identity.bridgeDeclareId,
+      identity.constantsMainnetBridgeProgram
+    ) && ok;
+  ok =
+    compare(
+      "relayer source declare_id vs constants mainnet baseRelayerProgram",
+      identity.relayerDeclareId,
+      identity.constantsMainnetBaseRelayerProgram
+    ) && ok;
+  ok =
+    compare(
+      "bridge source declare_id vs README mainnet bridge",
+      identity.bridgeDeclareId,
+      identity.readmeMainnetBridgeProgram
+    ) && ok;
+  ok =
+    compare(
+      "relayer source declare_id vs README mainnet base relayer",
+      identity.relayerDeclareId,
+      identity.readmeMainnetBaseRelayerProgram
+    ) && ok;
+
+  if (!ok) {
+    process.exit(1);
+  }
+}
+
+run();

--- a/solana/programs/base_relayer/src/errors.rs
+++ b/solana/programs/base_relayer/src/errors.rs
@@ -20,6 +20,24 @@ pub enum RelayerError {
     #[msg("Gas limit exceeded")]
     GasLimitExceeded,
 
+    #[msg("Invalid gas target")]
+    InvalidGasTarget,
+
+    #[msg("Invalid denominator")]
+    InvalidDenominator,
+
+    #[msg("Invalid window duration seconds")]
+    InvalidWindowDurationSeconds,
+
+    #[msg("Invalid gas cost scaler dp")]
+    InvalidGasCostScalerDp,
+
+    #[msg("Invalid gas config range")]
+    InvalidGasConfigRange,
+
+    #[msg("Gas cost overflow")]
+    GasCostOverflow,
+
     // Payment (6300-6399)
     #[msg("Incorrect gas fee receiver")]
     IncorrectGasFeeReceiver = 6300,

--- a/solana/programs/base_relayer/src/instructions/close_message_to_relay.rs
+++ b/solana/programs/base_relayer/src/instructions/close_message_to_relay.rs
@@ -1,0 +1,142 @@
+use anchor_lang::prelude::*;
+
+use crate::{
+    constants::{CFG_SEED, MTR_SEED},
+    state::{Cfg, MessageToRelay},
+    RelayerError,
+};
+
+#[derive(Accounts)]
+#[instruction(mtr_salt: [u8; 32])]
+pub struct CloseMessageToRelay<'info> {
+    #[account(
+        seeds = [CFG_SEED],
+        bump,
+        has_one = guardian @ RelayerError::UnauthorizedConfigUpdate
+    )]
+    pub cfg: Account<'info, Cfg>,
+
+    pub guardian: Signer<'info>,
+
+    #[account(
+        mut,
+        close = recipient,
+        seeds = [MTR_SEED, mtr_salt.as_ref()],
+        bump
+    )]
+    pub message_to_relay: Account<'info, MessageToRelay>,
+
+    /// CHECK: Any recipient is allowed; guardian authorizes this close.
+    #[account(mut)]
+    pub recipient: AccountInfo<'info>,
+}
+
+pub fn close_message_to_relay_handler(
+    _ctx: Context<CloseMessageToRelay>,
+    _mtr_salt: [u8; 32],
+) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::{setup_relayer, SetupRelayerResult, TEST_GAS_FEE_RECEIVER};
+    use crate::{accounts, instruction};
+    use anchor_lang::{
+        solana_program::{instruction::Instruction, system_program},
+        InstructionData, ToAccountMetas,
+    };
+    use solana_message::Message;
+    use solana_signer::Signer;
+    use solana_transaction::Transaction;
+
+    #[test]
+    fn close_message_to_relay_reclaims_rent_for_guardian_recipient() {
+        let SetupRelayerResult {
+            mut svm,
+            payer,
+            guardian,
+            cfg_pda,
+        } = setup_relayer();
+        let payer_pk = payer.pubkey();
+        let guardian_pk = guardian.pubkey();
+
+        // Ensure the configured gas fee receiver exists.
+        svm.airdrop(&TEST_GAS_FEE_RECEIVER, 1).unwrap();
+
+        // Create a MessageToRelay account via PayForRelay.
+        let outgoing_message = Pubkey::new_unique();
+        let gas_limit: u64 = 123_456;
+        let mtr_salt = Pubkey::new_unique().to_bytes();
+        let (message_to_relay, _) = Pubkey::find_program_address(
+            &[crate::constants::MTR_SEED, mtr_salt.as_ref()],
+            &crate::ID,
+        );
+
+        let pay_accounts = accounts::PayForRelay {
+            payer: payer_pk,
+            cfg: cfg_pda,
+            gas_fee_receiver: TEST_GAS_FEE_RECEIVER,
+            message_to_relay,
+            system_program: system_program::ID,
+        }
+        .to_account_metas(None);
+
+        let pay_ix = Instruction {
+            program_id: crate::ID,
+            accounts: pay_accounts,
+            data: instruction::PayForRelay {
+                mtr_salt,
+                outgoing_message,
+                gas_limit,
+            }
+            .data(),
+        };
+
+        let pay_tx = Transaction::new(
+            &[&payer],
+            Message::new(&[pay_ix], Some(&payer_pk)),
+            svm.latest_blockhash(),
+        );
+        svm.send_transaction(pay_tx)
+            .expect("failed to create message_to_relay");
+
+        let recipient_before = svm.get_account(&guardian_pk).unwrap().lamports;
+        let mtr_rent = svm.get_account(&message_to_relay).unwrap().lamports;
+
+        // Close and reclaim rent to guardian.
+        let close_accounts = accounts::CloseMessageToRelay {
+            cfg: cfg_pda,
+            guardian: guardian_pk,
+            message_to_relay,
+            recipient: guardian_pk,
+        }
+        .to_account_metas(None);
+
+        let close_ix = Instruction {
+            program_id: crate::ID,
+            accounts: close_accounts,
+            data: instruction::CloseMessageToRelay { mtr_salt }.data(),
+        };
+
+        let close_tx = Transaction::new(
+            &[&guardian],
+            Message::new(&[close_ix], Some(&guardian_pk)),
+            svm.latest_blockhash(),
+        );
+        svm.send_transaction(close_tx)
+            .expect("failed to close message_to_relay");
+
+        assert!(
+            svm.get_account(&message_to_relay).is_none(),
+            "message_to_relay account should be closed"
+        );
+
+        let recipient_after = svm.get_account(&guardian_pk).unwrap().lamports;
+        assert!(
+            recipient_after >= recipient_before + mtr_rent,
+            "recipient should recover at least closed account rent"
+        );
+    }
+}

--- a/solana/programs/base_relayer/src/instructions/config/set_eip1559_config.rs
+++ b/solana/programs/base_relayer/src/instructions/config/set_eip1559_config.rs
@@ -6,6 +6,7 @@ pub fn set_eip1559_config_handler(
     ctx: Context<SetConfig>,
     eip1559_config: Eip1559Config,
 ) -> Result<()> {
+    eip1559_config.validate()?;
     ctx.accounts.cfg.eip1559.config = eip1559_config;
     Ok(())
 }

--- a/solana/programs/base_relayer/src/instructions/config/set_gas_config.rs
+++ b/solana/programs/base_relayer/src/instructions/config/set_gas_config.rs
@@ -3,6 +3,7 @@ use anchor_lang::prelude::*;
 use crate::{instructions::SetConfig, internal::GasConfig};
 
 pub fn set_gas_config_handler(ctx: Context<SetConfig>, gas_config: GasConfig) -> Result<()> {
+    gas_config.validate()?;
     ctx.accounts.cfg.gas_config = gas_config;
     Ok(())
 }

--- a/solana/programs/base_relayer/src/instructions/initialize.rs
+++ b/solana/programs/base_relayer/src/instructions/initialize.rs
@@ -56,6 +56,9 @@ pub fn initialize_handler(
     eip1559_config: Eip1559Config,
     gas_config: GasConfig,
 ) -> Result<()> {
+    eip1559_config.validate()?;
+    gas_config.validate()?;
+
     let current_timestamp = Clock::get()?.unix_timestamp;
     let minimum_base_fee = eip1559_config.minimum_base_fee;
 

--- a/solana/programs/base_relayer/src/instructions/mod.rs
+++ b/solana/programs/base_relayer/src/instructions/mod.rs
@@ -1,7 +1,9 @@
 pub mod config;
+pub mod close_message_to_relay;
 pub mod initialize;
 pub mod pay_for_relay;
 
 pub use config::*;
+pub use close_message_to_relay::*;
 pub use initialize::*;
 pub use pay_for_relay::*;

--- a/solana/programs/base_relayer/src/internal/eip_1559.rs
+++ b/solana/programs/base_relayer/src/internal/eip_1559.rs
@@ -25,6 +25,18 @@ pub struct Eip1559Config {
     pub minimum_base_fee: u64,
 }
 
+impl Eip1559Config {
+    pub fn validate(&self) -> Result<()> {
+        require!(self.target > 0, crate::RelayerError::InvalidGasTarget);
+        require!(self.denominator > 0, crate::RelayerError::InvalidDenominator);
+        require!(
+            self.window_duration_seconds > 0,
+            crate::RelayerError::InvalidWindowDurationSeconds
+        );
+        Ok(())
+    }
+}
+
 impl Eip1559 {
     /// Refresh the base fee if window has expired, reset window tracking
     /// Handles multiple expired windows by processing each empty window

--- a/solana/programs/base_relayer/src/internal/gas_config.rs
+++ b/solana/programs/base_relayer/src/internal/gas_config.rs
@@ -16,6 +16,20 @@ pub struct GasConfig {
     pub gas_fee_receiver: Pubkey,
 }
 
+impl GasConfig {
+    pub fn validate(&self) -> Result<()> {
+        require!(
+            self.gas_cost_scaler_dp > 0,
+            RelayerError::InvalidGasCostScalerDp
+        );
+        require!(
+            self.min_gas_limit_per_message <= self.max_gas_limit_per_message,
+            RelayerError::InvalidGasConfigRange
+        );
+        Ok(())
+    }
+}
+
 pub fn check_and_pay_for_gas<'info>(
     system_program: &Program<'info, System>,
     payer: &Signer<'info>,
@@ -23,6 +37,8 @@ pub fn check_and_pay_for_gas<'info>(
     cfg: &mut Cfg,
     gas_limit: u64,
 ) -> Result<()> {
+    cfg.eip1559.config.validate()?;
+    cfg.gas_config.validate()?;
     check_gas_limit(gas_limit, cfg)?;
     pay_for_gas(system_program, payer, gas_fee_receiver, cfg, gas_limit)
 }
@@ -54,8 +70,14 @@ fn pay_for_gas<'info>(
     // Record gas usage for this transaction
     cfg.eip1559.add_gas_usage(gas_limit);
 
-    let gas_cost =
-        gas_limit * base_fee * cfg.gas_config.gas_cost_scaler / cfg.gas_config.gas_cost_scaler_dp;
+    let numerator = (gas_limit as u128)
+        .checked_mul(base_fee as u128)
+        .and_then(|v| v.checked_mul(cfg.gas_config.gas_cost_scaler as u128))
+        .ok_or_else(|| error!(RelayerError::GasCostOverflow))?;
+    let gas_cost = numerator
+        .checked_div(cfg.gas_config.gas_cost_scaler_dp as u128)
+        .ok_or_else(|| error!(RelayerError::InvalidGasCostScalerDp))?;
+    let gas_cost = u64::try_from(gas_cost).map_err(|_| error!(RelayerError::GasCostOverflow))?;
 
     let cpi_ctx = CpiContext::new(
         system_program.to_account_info(),

--- a/solana/programs/base_relayer/src/lib.rs
+++ b/solana/programs/base_relayer/src/lib.rs
@@ -109,4 +109,12 @@ pub mod base_relayer {
     ) -> Result<()> {
         pay_for_relay_handler(ctx, mtr_salt, outgoing_message, gas_limit)
     }
+
+    /// Closes a `MessageToRelay` account and returns rent to `recipient`.
+    pub fn close_message_to_relay(
+        ctx: Context<CloseMessageToRelay>,
+        mtr_salt: [u8; 32],
+    ) -> Result<()> {
+        close_message_to_relay_handler(ctx, mtr_salt)
+    }
 }

--- a/solana/programs/bridge/src/base_to_solana/instructions/register_output_root.rs
+++ b/solana/programs/bridge/src/base_to_solana/instructions/register_output_root.rs
@@ -95,6 +95,15 @@ pub fn register_output_root_handler(
         let partner_oracle_config = &ctx.accounts.bridge.partner_oracle_config;
         let partner_config =
             Signers::try_deserialize(&mut &ctx.accounts.partner_config.data.borrow()[..])?;
+
+        for signer in unique_signers.iter() {
+            if ctx.accounts.bridge.base_oracle_config.contains(signer)
+                && partner_config.contains(signer)
+            {
+                return err!(BridgeError::OverlappingOracleSignerSets);
+            }
+        }
+
         let partner_approved_count = partner_config.count_approvals(&unique_signers);
         require!(
             partner_approved_count as u8 >= partner_oracle_config.required_threshold,

--- a/solana/programs/bridge/src/base_to_solana/state/signers.rs
+++ b/solana/programs/bridge/src/base_to_solana/state/signers.rs
@@ -47,6 +47,17 @@ pub struct PartnerSigner {
 }
 
 impl Signers {
+    /// Returns true if the given EVM signer exists in this partner signer set.
+    pub fn contains(&self, signer: &[u8; 20]) -> bool {
+        self.signers.iter().any(|configured| {
+            configured.evm_address == *signer
+                || configured
+                    .new_evm_address
+                    .as_ref()
+                    .is_some_and(|new_addr| new_addr == signer)
+        })
+    }
+
     /// Count how many of the provided EVM addresses are authorized partner signers.
     ///
     /// - `signers` should contain unique 20-byte addresses. The caller (e.g.

--- a/solana/programs/bridge/src/common/instructions/config/eip1559.rs
+++ b/solana/programs/bridge/src/common/instructions/config/eip1559.rs
@@ -27,6 +27,7 @@ pub fn set_gas_target_handler(
     new_target: u64,
 ) -> Result<()> {
     ctx.accounts.bridge.eip1559.config.target = new_target;
+    ctx.accounts.bridge.eip1559.config.validate()?;
     Ok(())
 }
 

--- a/solana/programs/bridge/src/common/instructions/config/gas.rs
+++ b/solana/programs/bridge/src/common/instructions/config/gas.rs
@@ -8,6 +8,7 @@ pub fn set_gas_cost_scaler_handler(
     new_scaler: u64,
 ) -> Result<()> {
     ctx.accounts.bridge.gas_config.gas_cost_scaler = new_scaler;
+    ctx.accounts.bridge.gas_config.validate()?;
     Ok(())
 }
 
@@ -36,5 +37,6 @@ pub fn set_gas_per_call_handler(
     new_val: u64,
 ) -> Result<()> {
     ctx.accounts.bridge.gas_config.gas_per_call = new_val;
+    ctx.accounts.bridge.gas_config.validate()?;
     Ok(())
 }

--- a/solana/programs/bridge/src/common/state/bridge.rs
+++ b/solana/programs/bridge/src/common/state/bridge.rs
@@ -60,6 +60,7 @@ pub struct Eip1559Config {
 
 impl Eip1559Config {
     pub fn validate(&self) -> Result<()> {
+        require!(self.target > 0, BridgeError::InvalidGasTarget);
         require!(self.denominator > 0, BridgeError::InvalidDenominator);
         require!(
             self.window_duration_seconds > 0,

--- a/solana/programs/bridge/src/errors.rs
+++ b/solana/programs/bridge/src/errors.rs
@@ -128,6 +128,9 @@ pub enum BridgeError {
     #[msg("Invalid partner threshold")]
     InvalidPartnerThreshold,
 
+    #[msg("Invalid gas target")]
+    InvalidGasTarget,
+
     #[msg("Invalid denominator")]
     InvalidDenominator,
 
@@ -136,6 +139,9 @@ pub enum BridgeError {
 
     #[msg("Invalid gas cost scaler dp")]
     InvalidGasCostScalerDp,
+
+    #[msg("Gas cost overflow")]
+    GasCostOverflow,
 
     #[msg("Invalid block interval requirement")]
     InvalidBlockIntervalRequirement,
@@ -146,4 +152,7 @@ pub enum BridgeError {
 
     #[msg("Zero address")]
     ZeroAddress,
+
+    #[msg("Overlapping oracle signer sets")]
+    OverlappingOracleSignerSets,
 }

--- a/solana/programs/bridge/src/solana_to_base/instructions/mod.rs
+++ b/solana/programs/bridge/src/solana_to_base/instructions/mod.rs
@@ -35,6 +35,9 @@ pub fn pay_for_gas<'info>(
     gas_fee_receiver: &AccountInfo<'info>,
     bridge: &mut Bridge,
 ) -> Result<()> {
+    bridge.eip1559.config.validate()?;
+    bridge.gas_config.validate()?;
+
     // Get the base fee for the current window
     let current_timestamp = Clock::get()?.unix_timestamp;
     let base_fee = bridge.eip1559.refresh_base_fee(current_timestamp);
@@ -42,8 +45,14 @@ pub fn pay_for_gas<'info>(
     // Record gas usage for this transaction
     bridge.eip1559.add_gas_usage(bridge.gas_config.gas_per_call);
 
-    let gas_cost = bridge.gas_config.gas_per_call * base_fee * bridge.gas_config.gas_cost_scaler
-        / bridge.gas_config.gas_cost_scaler_dp;
+    let numerator = (bridge.gas_config.gas_per_call as u128)
+        .checked_mul(base_fee as u128)
+        .and_then(|v| v.checked_mul(bridge.gas_config.gas_cost_scaler as u128))
+        .ok_or_else(|| error!(BridgeError::GasCostOverflow))?;
+    let gas_cost = numerator
+        .checked_div(bridge.gas_config.gas_cost_scaler_dp as u128)
+        .ok_or_else(|| error!(BridgeError::InvalidGasCostScalerDp))?;
+    let gas_cost = u64::try_from(gas_cost).map_err(|_| error!(BridgeError::GasCostOverflow))?;
 
     let cpi_ctx = CpiContext::new(
         system_program.to_account_info(),


### PR DESCRIPTION
## Summary
- Add domain-aware validator signature hashing with guarded legacy fallback, signer sorting, and overlap protections plus guardian-controlled compatibility toggle coverage.
- Enforce canonical remote-token route registration and scalar safety/idempotency in `TokenLib` and bridge tests.
- Harden Solana gas config validation and arithmetic overflow handling, block overlapping oracle signer sets, add guardian relayer cleanup instruction, and add program-identity attestation tooling.

## Test plan
- [x] `cd base && forge test --match-contract BridgeValidatorTest`
- [x] `cd base && forge test --match-contract TokenLibTest`
- [x] `cd base && forge test --match-contract BridgeTest`
- [x] `cd solana && cargo check -p base_relayer`
- [x] `cd solana && cargo check -p bridge`
- [ ] `cd solana && cargo test -p base_relayer --tests close_message_to_relay_reclaims_rent_for_guardian_recipient` *(expected to require `target/deploy/base_relayer.so` in source-only environment)*
- [ ] `cd scripts && bun run verify:program-identity` *(expected non-zero in source-vs-mainnet mismatch mode)*

Made with [Cursor](https://cursor.com)